### PR TITLE
Refine CSAT card layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,34 +154,45 @@
     @media (max-width:960px){.kpis{grid-template-columns:1fr}}
     .kpi{padding:16px;text-align:center}
     .kpi h4{margin:6px 0 8px 0}
-    .csat{display:grid;grid-template-columns:minmax(160px,220px) 1fr;align-items:flex-start;gap:18px;width:100%}
-    @media (max-width:600px){.csat{grid-template-columns:1fr}}
-    .csat-scale{display:flex;flex-direction:column;align-items:flex-start;gap:10px;width:100%}
-    .csat-tier{display:grid;grid-template-columns:auto 1fr;align-items:center;gap:12px;width:100%}
-    .csat-star-btn{all:unset;cursor:pointer;padding:8px 12px;border-radius:12px;background:var(--chip);border:1px solid var(--line);color:var(--muted);font-size:14px;font-weight:700;letter-spacing:.05em;display:flex;align-items:center;gap:6px;min-width:140px;justify-content:flex-start;text-align:left;width:100%}
-    .csat-star-btn:hover,.csat-star-btn:focus-visible{background:var(--accent);color:#fff;box-shadow:var(--shadow)}
-    .csat-star-btn.active{background:var(--accent);color:#fff;box-shadow:var(--shadow)}
-    .csat-counts{width:100%}
-    .csat-count{display:flex;align-items:center;justify-content:space-between;gap:8px;padding:6px 12px;border-radius:999px;background:var(--chip);border:1px solid var(--line);font-size:.85rem;font-weight:600;color:inherit;width:100%}
+    .csat{display:grid;grid-template-columns:minmax(160px,220px) minmax(220px,1fr) auto;align-items:flex-start;gap:18px;width:100%}
+    @media (max-width:900px){.csat{grid-template-columns:1fr;}}
+    .csat-hero{display:flex;flex-direction:column;align-items:flex-start;gap:12px;width:100%}
+    .csat-face{font-size:44px;margin:0}
+    .csat-hero-details{display:flex;flex-direction:column;gap:10px;align-items:flex-start;width:100%}
+    .csat-rate-stars{display:flex;align-items:center;gap:8px;background:linear-gradient(135deg,rgba(255,255,255,.04),rgba(255,255,255,.01));padding:8px 12px;border-radius:16px;border:1px solid var(--line)}
+    .csat-star-btn{all:unset;cursor:pointer;width:38px;height:38px;border-radius:50%;display:grid;place-items:center;font-size:18px;font-weight:700;color:var(--muted);background:var(--chip);border:1px solid var(--line);transition:transform .2s ease,box-shadow .25s ease,background .25s ease,color .25s ease;opacity:.7}
+    .csat-star-btn:hover,.csat-star-btn:focus-visible{transform:translateY(-2px);background:var(--accent);color:#fff;box-shadow:var(--shadow)}
+    .csat-star-btn.active{background:var(--accent);color:#fff;box-shadow:var(--shadow);opacity:1}
+    .csat-meta{font-size:.85rem;display:flex;align-items:center;gap:6px;color:var(--muted)}
+    .csat-meta span{font-variant-numeric:tabular-nums}
+    .csat-body{display:grid;grid-template-columns:minmax(220px,1fr) auto;gap:16px;width:100%;align-items:start}
+    .csat-counts{display:flex;flex-direction:column;gap:10px;width:100%}
+    .csat-count{display:flex;justify-content:space-between;align-items:center;gap:12px;padding:10px 14px;border-radius:18px;background:var(--chip);border:1px solid var(--line);font-size:.95rem;font-weight:600;color:inherit;transition:transform .2s ease,box-shadow .25s ease,border-color .25s ease}
+    .csat-count .sentiment{display:flex;align-items:center;gap:10px;font-weight:700}
     .csat-count .count{font-variant-numeric:tabular-nums;font-weight:700;letter-spacing:1px}
-    .csat-tier .csat-star-btn.active + .csat-count{border-color:var(--accent);box-shadow:var(--shadow)}
-    .csat-trend{margin-top:12px;padding-top:6px;width:100%;border-top:1px dashed var(--line)}
-    .csat-side{display:flex;flex-direction:column;align-items:flex-start;gap:12px;width:100%}
-    .csat-face{font-size:40px;margin-bottom:0}
+    .csat-count.leader{border-color:var(--accent);box-shadow:var(--shadow);transform:translateY(-2px)}
+    .csat-trend{display:flex;flex-direction:column;align-items:flex-end;gap:8px;padding-top:6px}
+    .csat-trend canvas{width:110px;height:64px;max-width:100%;border-radius:12px;border:1px solid var(--line);background:rgba(255,255,255,.04)}
+    .csat-trend span{font-size:.75rem;color:var(--muted);text-transform:uppercase;letter-spacing:.08em}
     .csat-footer{display:flex;flex-direction:column;align-items:flex-start;margin-top:0;gap:10px;width:100%}
     .csat-footer .muted{text-align:left;max-width:260px}
-    #csatTrend{width:100%;max-width:100%;height:60px;border-radius:10px;border:1px solid var(--line);background:rgba(255,255,255,.04);display:block}
-    @media (max-width:600px){
-      .csat-side{align-items:center;text-align:center}
-      .csat-footer{align-items:center}
-      .csat-footer .muted{text-align:center}
+    @media (max-width:900px){
+      .csat-hero,.csat-footer{align-items:center;text-align:center}
+      .csat-hero-details,.csat-footer{width:100%;align-items:center}
+      .csat-rate-stars{justify-content:center}
+      .csat-meta{justify-content:center}
+      .csat-body{grid-template-columns:1fr;justify-items:center}
+      .csat-counts{width:100%}
+      .csat-trend{width:100%;align-items:center}
+      .csat-trend canvas{width:180px}
     }
+    html[data-theme="light"] .csat-rate-stars{background:linear-gradient(135deg,rgba(10,14,26,.04),rgba(10,14,26,.02));border-color:var(--line-light)}
     html[data-theme="light"] .csat-star-btn{background:#eef1fb;border-color:var(--line-light);color:var(--muted-light)}
-    html[data-theme="light"] .csat-star-btn:hover,html[data-theme="light"] .csat-star-btn:focus-visible,html[data-theme="light"] .csat-star-btn.active{background:var(--accent);color:#fff}
+    html[data-theme="light"] .csat-star-btn.active,html[data-theme="light"] .csat-star-btn:hover,html[data-theme="light"] .csat-star-btn:focus-visible{background:var(--accent);color:#fff}
     html[data-theme="light"] .csat-count{background:#eef1fb;border-color:var(--line-light);color:var(--ink-light)}
-    html[data-theme="light"] .csat-tier .csat-star-btn.active + .csat-count{border-color:var(--accent);box-shadow:var(--shadow-light)}
-    html[data-theme="light"] .csat-trend{border-top-color:var(--line-light)}
-    html[data-theme="light"] #csatTrend{background:rgba(10,14,26,.05);border-color:var(--line-light)}
+    html[data-theme="light"] .csat-count.leader{box-shadow:var(--shadow-light)}
+    html[data-theme="light"] .csat-trend canvas{background:rgba(10,14,26,.05);border-color:var(--line-light)}
+    html[data-theme="light"] .csat-trend span{color:var(--muted-light)}
     .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
     .counter{margin-bottom:8px;font-size:.9rem;text-align:left;line-height:1.4}
     .counter div{display:flex;justify-content:space-between}
@@ -426,66 +437,54 @@
         <div class="card kpi" id="kpi1">
           <h4 data-en="Customer Satisfaction" data-es="Satisfacción del cliente">Customer Satisfaction</h4>
           <div class="csat">
-            <div class="csat-scale csat-counts" id="csatCounts" aria-live="polite">
-              <div class="csat-tier" data-val="5">
-                <button type="button" class="csat-star-btn" aria-label="5 stars" data-val="5">
-                  <span aria-hidden="true">★★★★★</span>
-                  <span class="sr-only">5 stars</span>
-                </button>
+            <div class="csat-hero">
+              <div class="csat-face" role="img" aria-live="polite">😐</div>
+              <div class="csat-hero-details">
+                <div class="csat-rate-stars" role="group" aria-label="Rate customer satisfaction">
+                  <button type="button" class="csat-star-btn" aria-label="1 star" data-val="1">★</button>
+                  <button type="button" class="csat-star-btn" aria-label="2 stars" data-val="2">★</button>
+                  <button type="button" class="csat-star-btn" aria-label="3 stars" data-val="3">★</button>
+                  <button type="button" class="csat-star-btn" aria-label="4 stars" data-val="4">★</button>
+                  <button type="button" class="csat-star-btn" aria-label="5 stars" data-val="5">★</button>
+                </div>
+                <div class="csat-meta" aria-live="polite">
+                  <span id="csatAverageValue">0.00</span><span>/5</span>
+                  <span>•</span>
+                  <span id="csatTotalVotes">0</span>
+                  <span id="csatVotesLabel" data-en="votes" data-es="votos">votes</span>
+                </div>
+                <div class="csat-footer">
+                  <button class="btn" id="rateBtn" data-en="Rate" data-es="Calificar">Rate</button>
+                  <div class="muted" data-en="Keep delighting guests." data-es="Sigue encantando a los clientes.">Keep delighting guests.</div>
+                </div>
+              </div>
+            </div>
+            <div class="csat-body">
+              <div class="csat-counts" id="csatCounts" aria-live="polite">
                 <div class="csat-count" data-val="5" data-label-en="Delighted" data-label-es="Encantado">
-                  <span aria-hidden="true">🤩</span>
+                  <span class="sentiment"><span aria-hidden="true">🤩</span><span data-en="Delighted" data-es="Encantado">Delighted</span></span>
                   <span class="count">000 000</span>
                 </div>
-              </div>
-              <div class="csat-tier" data-val="4">
-                <button type="button" class="csat-star-btn" aria-label="4 stars" data-val="4">
-                  <span aria-hidden="true">★★★★</span>
-                  <span class="sr-only">4 stars</span>
-                </button>
                 <div class="csat-count" data-val="4" data-label-en="Happy" data-label-es="Contento">
-                  <span aria-hidden="true">😄</span>
+                  <span class="sentiment"><span aria-hidden="true">😄</span><span data-en="Happy" data-es="Contento">Happy</span></span>
                   <span class="count">000 000</span>
                 </div>
-              </div>
-              <div class="csat-tier" data-val="3">
-                <button type="button" class="csat-star-btn" aria-label="3 stars" data-val="3">
-                  <span aria-hidden="true">★★★</span>
-                  <span class="sr-only">3 stars</span>
-                </button>
                 <div class="csat-count" data-val="3" data-label-en="Neutral" data-label-es="Neutral">
-                  <span aria-hidden="true">😐</span>
+                  <span class="sentiment"><span aria-hidden="true">😐</span><span data-en="Neutral" data-es="Neutral">Neutral</span></span>
                   <span class="count">000 000</span>
                 </div>
-              </div>
-              <div class="csat-tier" data-val="2">
-                <button type="button" class="csat-star-btn" aria-label="2 stars" data-val="2">
-                  <span aria-hidden="true">★★</span>
-                  <span class="sr-only">2 stars</span>
-                </button>
                 <div class="csat-count" data-val="2" data-label-en="Unhappy" data-label-es="Insatisfecho">
-                  <span aria-hidden="true">🙁</span>
+                  <span class="sentiment"><span aria-hidden="true">🙁</span><span data-en="Unhappy" data-es="Insatisfecho">Unhappy</span></span>
                   <span class="count">000 000</span>
                 </div>
-              </div>
-              <div class="csat-tier" data-val="1">
-                <button type="button" class="csat-star-btn" aria-label="1 star" data-val="1">
-                  <span aria-hidden="true">★</span>
-                  <span class="sr-only">1 star</span>
-                </button>
                 <div class="csat-count" data-val="1" data-label-en="Very unhappy" data-label-es="Muy insatisfecho">
-                  <span aria-hidden="true">😞</span>
+                  <span class="sentiment"><span aria-hidden="true">😞</span><span data-en="Very unhappy" data-es="Muy insatisfecho">Very unhappy</span></span>
                   <span class="count">000 000</span>
                 </div>
               </div>
               <div class="csat-trend">
-                <canvas id="csatTrend" width="220" height="60" role="img" aria-label="Customer satisfaction trend"></canvas>
-              </div>
-            </div>
-            <div class="csat-side">
-              <div class="csat-face" role="img" aria-live="polite">😐</div>
-              <div class="csat-footer">
-                <button class="btn" id="rateBtn" data-en="Rate" data-es="Calificar">Rate</button>
-                <div class="muted" data-en="Keep delighting guests." data-es="Sigue encantando a los clientes.">Keep delighting guests.</div>
+                <canvas id="csatTrend" width="110" height="64" role="img" aria-label="Customer satisfaction trend"></canvas>
+                <span class="muted" data-en="Trend" data-es="Tendencia">Trend</span>
               </div>
             </div>
           </div>
@@ -1305,17 +1304,28 @@
       const msgEn=`Live avg: ${stats.average.toFixed(2)} (${stats.total} votes)`;
       const msgEs=`Promedio: ${stats.average.toFixed(2)} (${stats.total} votos)`;
       el.textContent=(lang==='en')?msgEn:msgEs;
+      const avgEl=document.getElementById('csatAverageValue');
+      if(avgEl) avgEl.textContent=stats.average.toFixed(2);
+      const totalEl=document.getElementById('csatTotalVotes');
+      if(totalEl) totalEl.textContent=(stats.total||0).toLocaleString();
+      const votesLabel=document.getElementById('csatVotesLabel');
+      if(votesLabel){
+        const label=lang==='es'?(votesLabel.dataset.es||votesLabel.dataset.en||votesLabel.textContent):
+          (votesLabel.dataset.en||votesLabel.textContent);
+        votesLabel.textContent=label;
+      }
     }
 
     function initCsat(){
       let rating=0;
-      const stars=document.querySelectorAll('.csat-star-btn');
+      const stars=Array.from(document.querySelectorAll('.csat-star-btn'));
       const face=document.querySelector('.csat-face');
       const moods=['😞','🙁','😐','😄','🤩'];
       const countWrap=document.getElementById('csatCounts');
-      const countNodes=countWrap?Array.from(countWrap.querySelectorAll('.csat-count')):[];
+      let countNodes=countWrap?Array.from(countWrap.querySelectorAll('.csat-count')):[];
       const trendCanvas=document.getElementById('csatTrend');
       let counts=[0,0,0,0,0];
+      const STORAGE_KEY='csatCounts';
 
       const safeParse=(key,fallback)=>{
         try{
@@ -1351,8 +1361,8 @@
         const ctx=trendCanvas.getContext('2d');
         if(!ctx) return;
         const dpr=window.devicePixelRatio||1;
-        const cssW=trendCanvas.clientWidth||trendCanvas.width||220;
-        const cssH=trendCanvas.clientHeight||trendCanvas.height||60;
+        const cssW=trendCanvas.clientWidth||trendCanvas.width||110;
+        const cssH=trendCanvas.clientHeight||trendCanvas.height||64;
         const width=Math.round(cssW*dpr);
         const height=Math.round(cssH*dpr);
         if(trendCanvas.width!==width||trendCanvas.height!==height){
@@ -1399,8 +1409,21 @@
         });
       };
 
+      const getLeaderRating=()=>{
+        let bestIdx=-1;
+        let bestVal=-1;
+        counts.forEach((val,idx)=>{
+          if(val>bestVal || (val===bestVal && idx>bestIdx)){
+            bestVal=val;
+            bestIdx=idx;
+          }
+        });
+        return bestVal>0?bestIdx+1:0;
+      };
+
       const updateCountsUI=()=>{
-        if(!countNodes.length) return;
+        if(!countWrap) return;
+        countNodes=Array.from(countWrap.querySelectorAll('.csat-count'));
         countNodes.forEach((node)=>{
           const ratingIdx=(Number(node.dataset.val)||0)-1;
           const val=counts[ratingIdx]||0;
@@ -1410,12 +1433,44 @@
           const text=label?`${label}: ${val}`:`${val} ${t('ratings','calificaciones')}`;
           node.setAttribute('aria-label',text);
           node.setAttribute('title',text);
+          node.dataset.count=String(val);
         });
+        const sorted=[...countNodes].sort((a,b)=>{
+          const valA=Number(a.dataset.count)||0;
+          const valB=Number(b.dataset.count)||0;
+          if(valA===valB){
+            return (Number(b.dataset.val)||0)-(Number(a.dataset.val)||0);
+          }
+          return valB-valA;
+        });
+        sorted.forEach((node,idx)=>{
+          node.classList.toggle('leader',idx===0 && (Number(node.dataset.count)||0)>0);
+          countWrap.appendChild(node);
+        });
+        countNodes=sorted;
+        const totalVotes=counts.reduce((sum,val)=>sum+val,0);
+        const avg=totalVotes?counts.reduce((sum,val,idx)=>sum+val*(idx+1),0)/totalVotes:0;
+        const avgEl=document.getElementById('csatAverageValue');
+        if(avgEl) avgEl.textContent=avg.toFixed(2);
+        const totalEl=document.getElementById('csatTotalVotes');
+        if(totalEl) totalEl.textContent=totalVotes.toLocaleString();
+        const votesLabel=document.getElementById('csatVotesLabel');
+        if(votesLabel){
+          const label=lang==='es'?(votesLabel.dataset.es||votesLabel.dataset.en||votesLabel.textContent):
+            (votesLabel.dataset.en||votesLabel.textContent);
+          votesLabel.textContent=label;
+        }
         renderTrend();
+        if(!rating) paint(0);
       };
 
       window.updateCsatCountsUI=updateCountsUI;
       window.renderCsatTrend=renderTrend;
+
+      const persistCounts=()=>{
+        try{ localStorage.setItem(STORAGE_KEY, JSON.stringify(counts)); }
+        catch(err){ console.warn('Unable to persist CSAT counts.',err); }
+      };
 
       const updateCounts=(val)=>{
         if(val<1||val>counts.length) return;
@@ -1425,13 +1480,15 @@
       };
 
       const paint=val=>{
+        const selectedVal=val>0?val:0;
+        const displayVal=selectedVal||getLeaderRating();
         stars.forEach(btn=>{
           const btnVal=Number(btn.dataset.val)||0;
-          const isActive=val>0 && btnVal===val;
-          btn.classList.toggle('active',isActive);
-          btn.setAttribute('aria-pressed',isActive?'true':'false');
+          const isFilled=displayVal>0 && btnVal<=displayVal;
+          btn.classList.toggle('active',isFilled);
+          btn.setAttribute('aria-pressed',btnVal===selectedVal?'true':'false');
         });
-        const moodIdx=val?Math.min(Math.max(val-1,0),moods.length-1):2;
+        const moodIdx=displayVal?Math.min(Math.max(displayVal-1,0),moods.length-1):2;
         face.textContent=moods[moodIdx];
       };
 
@@ -1586,8 +1643,7 @@
           if(!res.ok||!data.ok) throw new Error(data.error||'csat_error');
           const idx=Math.max(0,Math.min(counts.length-1,rating-1));
           counts[idx]=(counts[idx]||0)+1;
-          try{ localStorage.setItem('csatCounts', JSON.stringify(counts)); }
-          catch(err){ console.warn('Unable to persist CSAT counts.',err); }
+          persistCounts();
           updateCountsUI();
           showCsatStats(data.stats);
           alert(t('Thanks for rating!','¡Gracias por calificar!'));


### PR DESCRIPTION
## Summary
- rework the customer satisfaction KPI card to surface the five-star selector, summary metrics, and compact trend chart
- refresh the CSAT styling for the new layout, including responsive behavior and emphasis on the leading sentiment
- update the CSAT logic to sort ratings dynamically, persist counts, and keep the average and totals in sync with the UI

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d44f997f30832b83c011c639089a5e