### PR TITLE
Remove static CSAT count column

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,8 +159,9 @@
     .csat-hero{display:flex;flex-direction:column;align-items:flex-start;gap:14px;width:100%}
     .csat-label{text-transform:uppercase;font-size:.75rem;letter-spacing:.16em;color:var(--muted)}
     .sentiment-score{color:var(--danger);font-weight:800;margin-left:8px;min-width:12px;display:inline-flex;align-items:center;justify-content:center}
-    .csat-hero-summary{display:flex;align-items:center;gap:16px}
+    .csat-hero-summary{display:flex;align-items:flex-start;gap:16px}
     .csat-face{font-size:44px;margin:0}
+    .csat-face-wrap{display:flex;flex-direction:column;align-items:center;gap:12px}
     .csat-meta{display:flex;flex-direction:column;gap:10px;align-items:flex-start;color:var(--muted)}
     .csat-average{display:flex;align-items:baseline;gap:8px;color:var(--ink);font-size:2.6rem;font-weight:800;line-height:1}
     .csat-average span{font-variant-numeric:tabular-nums}
@@ -173,9 +174,8 @@
     .csat-body{display:grid;grid-template-columns:minmax(260px,1fr) minmax(140px,1fr);gap:16px;width:100%;align-items:start}
     .csat-baseline{display:grid;gap:16px;align-content:start}
     .csat-counts{display:flex;flex-direction:column;gap:10px;width:100%}
-    .csat-count{display:flex;justify-content:space-between;align-items:center;gap:12px;padding:10px 14px;border-radius:18px;background:var(--chip);border:1px solid var(--line);font-size:.95rem;font-weight:600;color:inherit;transition:transform .2s ease,box-shadow .25s ease,border-color .25s ease}
+    .csat-count{display:flex;align-items:center;gap:12px;padding:10px 14px;border-radius:18px;background:var(--chip);border:1px solid var(--line);font-size:.95rem;font-weight:600;color:inherit;transition:transform .2s ease,box-shadow .25s ease,border-color .25s ease}
     .csat-count .sentiment{display:flex;align-items:center;gap:10px;font-weight:700}
-    .csat-count .count{font-variant-numeric:tabular-nums;font-weight:700;letter-spacing:1px}
     .csat-count.leader{border-color:var(--accent);box-shadow:var(--shadow);transform:translateY(-2px)}
     .csat-trend{display:flex;flex-direction:column;align-items:flex-end;gap:8px;padding-top:6px}
     .csat-trend canvas{width:110px;height:64px;max-width:100%;border-radius:12px;border:1px solid var(--line);background:rgba(255,255,255,.04)}
@@ -184,8 +184,9 @@
     .csat-footer .muted{text-align:left;max-width:260px}
     @media (max-width:900px){
       .csat-hero{align-items:center;text-align:center}
-      .csat-hero-summary{flex-direction:column}
+      .csat-hero-summary{flex-direction:column;align-items:center}
       .csat-meta{align-items:center;text-align:center}
+      .csat-face-wrap{width:100%}
       .csat-rate-stars{justify-content:center}
       .csat-body{grid-template-columns:1fr;justify-items:center}
       .csat-baseline{width:100%}
@@ -449,7 +450,16 @@
             <div class="csat-hero">
               <span class="csat-label" data-en="Previous sentiment rate" data-es="Índice de sentimiento previo">Previous sentiment rate</span>
               <div class="csat-hero-summary">
-                <div class="csat-face" role="img" aria-live="polite">😐</div>
+                <div class="csat-face-wrap">
+                  <div class="csat-face" role="img" aria-live="polite">😐</div>
+                  <div class="csat-rate-stars" role="group" aria-label="Rate customer satisfaction">
+                    <button type="button" class="csat-star-btn" aria-label="1 star" data-val="1">★</button>
+                    <button type="button" class="csat-star-btn" aria-label="2 stars" data-val="2">★</button>
+                    <button type="button" class="csat-star-btn" aria-label="3 stars" data-val="3">★</button>
+                    <button type="button" class="csat-star-btn" aria-label="4 stars" data-val="4">★</button>
+                    <button type="button" class="csat-star-btn" aria-label="5 stars" data-val="5">★</button>
+                  </div>
+                </div>
                 <div class="csat-meta" aria-live="polite">
                   <div class="csat-average">
                     <span id="csatAverageValue">0.00</span><span>/5</span>
@@ -467,33 +477,21 @@
             </div>
             <div class="csat-body">
               <div class="csat-baseline">
-                <div class="csat-rate-stars" role="group" aria-label="Rate customer satisfaction">
-                  <button type="button" class="csat-star-btn" aria-label="1 star" data-val="1">★</button>
-                  <button type="button" class="csat-star-btn" aria-label="2 stars" data-val="2">★</button>
-                  <button type="button" class="csat-star-btn" aria-label="3 stars" data-val="3">★</button>
-                  <button type="button" class="csat-star-btn" aria-label="4 stars" data-val="4">★</button>
-                  <button type="button" class="csat-star-btn" aria-label="5 stars" data-val="5">★</button>
-                </div>
                 <div class="csat-counts" id="csatCounts" aria-live="polite">
                   <div class="csat-count" data-val="5" data-label-en="Delighted" data-label-es="Encantado">
                     <span class="sentiment"><span aria-hidden="true">🤩</span><span class="sentiment-score" data-en="1" data-es="1">1</span></span>
-                    <span class="count">000 000</span>
                   </div>
                   <div class="csat-count" data-val="4" data-label-en="Happy" data-label-es="Contento">
                     <span class="sentiment"><span aria-hidden="true">😄</span><span class="sentiment-score" data-en="1" data-es="1">1</span></span>
-                    <span class="count">000 000</span>
                   </div>
                   <div class="csat-count" data-val="3" data-label-en="Neutral" data-label-es="Neutral">
                     <span class="sentiment"><span aria-hidden="true">😐</span><span class="sentiment-score" data-en="1" data-es="1">1</span></span>
-                    <span class="count">000 000</span>
                   </div>
                   <div class="csat-count" data-val="2" data-label-en="Unhappy" data-label-es="Insatisfecho">
                     <span class="sentiment"><span aria-hidden="true">🙁</span><span class="sentiment-score" data-en="1" data-es="1">1</span></span>
-                    <span class="count">000 000</span>
                   </div>
                   <div class="csat-count" data-val="1" data-label-en="Very unhappy" data-label-es="Muy insatisfecho">
                     <span class="sentiment"><span aria-hidden="true">😞</span><span data-en="Very unhappy" data-es="Muy insatisfecho">Very unhappy</span></span>
-                    <span class="count">000 000</span>
                   </div>
                 </div>
               </div>
@@ -1364,13 +1362,6 @@
         }
       }
 
-      const formatCount=val=>{
-        if(!Number.isFinite(val)||val<0) val=0;
-        if(val>999999) return val.toLocaleString();
-        const padded=String(val).padStart(6,'0');
-        return `${padded.slice(0,3)} ${padded.slice(3)}`;
-      };
-
       const renderTrend=()=>{
         if(!trendCanvas) return;
         const ctx=trendCanvas.getContext('2d');
@@ -1442,8 +1433,6 @@
         countNodes.forEach((node)=>{
           const ratingIdx=(Number(node.dataset.val)||0)-1;
           const val=counts[ratingIdx]||0;
-          const span=node.querySelector('.count');
-          if(span) span.textContent=formatCount(val);
           const label=lang==='en'?(node.dataset.labelEn||''):(node.dataset.labelEs||node.dataset.labelEn||'');
           const text=label?`${label}: ${val}`:`${val} ${t('ratings','calificaciones')}`;
           node.setAttribute('aria-label',text);


### PR DESCRIPTION
## Summary
- remove the static placeholder column from the CSAT counts list
- simplify the related layout and JavaScript that previously formatted the placeholder values
- reposition the CSAT star rating control so it sits directly beneath the sentiment emoticon

## Testing
- not run (static site with no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d499d22de4832bbdd92f3865125b4e