### PR TITLE
Remove unused sentiment label elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -448,7 +448,6 @@
           <h4 data-en="Customer Satisfaction" data-es="Satisfacción del cliente">Customer Satisfaction</h4>
           <div class="csat">
             <div class="csat-hero">
-              <span class="csat-label" data-en="Previous sentiment rate" data-es="Índice de sentimiento previo">Previous sentiment rate</span>
               <div class="csat-hero-summary">
                 <div class="csat-face-wrap">
                   <div class="csat-face" role="img" aria-live="polite">😐</div>
@@ -489,9 +488,6 @@
                   </div>
                   <div class="csat-count" data-val="2" data-label-en="Unhappy" data-label-es="Insatisfecho">
                     <span class="sentiment"><span aria-hidden="true">🙁</span><span class="sentiment-score" data-en="1" data-es="1">1</span></span>
-                  </div>
-                  <div class="csat-count" data-val="1" data-label-en="Very unhappy" data-label-es="Muy insatisfecho">
-                    <span class="sentiment"><span aria-hidden="true">😞</span><span data-en="Very unhappy" data-es="Muy insatisfecho">Very unhappy</span></span>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- remove the previous sentiment rate label from the customer satisfaction widget
- drop the "Very unhappy" sentiment entry from the satisfaction breakdown to declutter the UI

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4a905b824832b86609c3fb72b6f13