### PR TITLE
Reposition CSAT score and trim rating list

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,7 +174,6 @@
     .csat-hero-summary{display:flex;align-items:flex-start;gap:16px}
     .csat-face{font-size:44px;margin:0}
     .csat-face-wrap{display:flex;flex-direction:column;align-items:center;gap:12px}
-    .csat-meta{display:flex;flex-direction:column;gap:10px;align-items:flex-start;color:var(--muted)}
     .csat-average{display:flex;align-items:baseline;gap:8px;color:var(--ink);font-size:2.6rem;font-weight:800;line-height:1}
     .csat-average span{font-variant-numeric:tabular-nums}
     .csat-votes{display:flex;align-items:center;gap:6px;font-size:.9rem}
@@ -196,20 +195,20 @@
     .csat-trend canvas{width:110px;height:64px;max-width:100%;border-radius:12px;border:1px solid var(--line);background:rgba(255,255,255,.04)}
     .csat-trend span{font-size:.75rem;color:var(--muted);text-transform:uppercase;letter-spacing:.08em}
     .csat-footer{display:flex;flex-direction:column;align-items:flex-start;margin-top:0;gap:10px;width:100%}
+    .csat-footer-primary{display:flex;align-items:center;gap:16px;flex-wrap:wrap}
     .csat-footer .muted{text-align:left;max-width:260px}
     @media (max-width:900px){
       .csat-hero{align-items:center;text-align:center}
       .csat-hero-summary{flex-direction:column;align-items:center}
-      .csat-meta{align-items:center;text-align:center}
       .csat-face-wrap{width:100%}
       .csat-rate-stars{justify-content:center}
+      .csat-footer-primary{justify-content:center}
       .csat-body{grid-template-columns:1fr;justify-items:center}
       .csat-baseline{width:100%}
       .csat-counts{width:100%}
       .csat-trend{width:100%;align-items:center}
       .csat-trend canvas{width:180px}
     }
-    html[data-theme="light"] .csat-meta{color:var(--muted-light)}
     html[data-theme="light"] .csat-average{color:var(--ink-light)}
     html[data-theme="light"] .csat-rate-stars{background:linear-gradient(135deg,rgba(10,14,26,.04),rgba(10,14,26,.02));border-color:var(--line-light)}
     html[data-theme="light"] .csat-star-btn{background:#eef1fb;border-color:var(--line-light);color:var(--muted-light)}
@@ -474,7 +473,10 @@
                     <button type="button" class="csat-star-btn" aria-label="5 stars" data-val="5">★</button>
                   </div>
                 </div>
-                <div class="csat-meta" aria-live="polite">
+              </div>
+              <div class="csat-footer">
+                <div class="csat-footer-primary" aria-live="polite">
+                  <button class="btn" id="rateBtn" data-en="Rate" data-es="Calificar">Rate</button>
                   <div class="csat-average">
                     <span id="csatAverageValue">0.00</span><span>/5</span>
                   </div>
@@ -483,15 +485,9 @@
                     <span id="csatVotesLabel" data-en="votes" data-es="votos">votes</span>
                   </div>
                 </div>
-              </div>
-              <div class="csat-footer">
-                <button class="btn" id="rateBtn" data-en="Rate" data-es="Calificar">Rate</button>
                 <div class="csat-counts" id="csatCounts" aria-live="polite">
                   <div class="csat-count" data-val="5" data-label-en="Delighted" data-label-es="Encantado">
                     <span class="sentiment"><span aria-hidden="true">🤩</span><span class="sentiment-score"></span></span>
-                  </div>
-                  <div class="csat-count" data-val="4" data-label-en="Happy" data-label-es="Contento">
-                    <span class="sentiment"><span aria-hidden="true">😄</span><span class="sentiment-score"></span></span>
                   </div>
                   <div class="csat-count" data-val="3" data-label-en="Neutral" data-label-es="Neutral">
                     <span class="sentiment"><span aria-hidden="true">😐</span><span class="sentiment-score"></span></span>


### PR DESCRIPTION
## Summary
- align the CSAT average and vote tally beside the Rate action for clearer context
- adjust the CSAT footer layout styles to support the new inline arrangement
- remove the Happy (4-star) sentiment chip from the customer satisfaction breakdown

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d4b263abb4832bbed454258538d7e6