### PR TITLE
Refine CSAT layout and remove trend chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,11 +150,11 @@
     /* Bottom split: KPIs left, totals right */
     .split{display:grid;grid-template-columns:2fr 1fr;gap:16px;margin-top:var(--section-gap)}
     @media (max-width:960px){.split{grid-template-columns:1fr}}
-    .kpis{display:grid;grid-template-columns:repeat(3,1fr);gap:16px}
+    .kpis{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:16px}
     @media (max-width:960px){.kpis{grid-template-columns:1fr}}
     .kpi{padding:16px;text-align:center}
     .kpi h4{margin:6px 0 8px 0}
-    .csat{display:grid;grid-template-columns:minmax(160px,220px) minmax(220px,1fr) auto;align-items:flex-start;gap:18px;width:100%}
+    .csat{display:grid;grid-template-columns:minmax(200px,240px) 1fr;align-items:stretch;gap:24px;width:100%}
     @media (max-width:900px){.csat{grid-template-columns:1fr;}}
     .csat-hero{display:flex;flex-direction:column;align-items:flex-start;gap:14px;width:100%}
     .csat-label{text-transform:uppercase;font-size:.75rem;letter-spacing:.16em;color:var(--muted)}
@@ -182,18 +182,14 @@
     .csat-star-btn{all:unset;cursor:pointer;width:38px;height:38px;border-radius:50%;display:grid;place-items:center;font-size:18px;font-weight:700;color:var(--muted);background:var(--chip);border:1px solid var(--line);transition:transform .2s ease,box-shadow .25s ease,background .25s ease,color .25s ease;opacity:.7}
     .csat-star-btn:hover,.csat-star-btn:focus-visible{transform:translateY(-2px);background:var(--accent);color:#fff;box-shadow:var(--shadow)}
     .csat-star-btn.active{background:var(--accent);color:#fff;box-shadow:var(--shadow);opacity:1}
-    .csat-body{display:grid;grid-template-columns:1fr;gap:16px;width:100%;align-items:start}
+    .csat-insights{display:flex;flex-direction:column;gap:16px;width:100%;align-items:stretch}
     .csat-baseline{display:grid;gap:16px;align-content:start}
-    .csat-counts{display:flex;flex-direction:column;gap:10px;width:100%}
-    .csat-footer .csat-counts{margin-top:6px}
+    .csat-counts{display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:12px;width:100%}
     .csat-count{display:flex;align-items:center;gap:12px;padding:10px 14px;border-radius:18px;background:var(--chip);border:1px solid var(--line);font-size:.95rem;font-weight:600;color:inherit;transition:transform .2s ease,box-shadow .25s ease,border-color .25s ease;width:100%}
     .csat-count .sentiment{display:flex;align-items:center;justify-content:space-between;gap:12px;width:100%;font-weight:700}
     .csat-count.leader{border-color:var(--accent);box-shadow:var(--shadow);transform:translateY(-2px)}
     .csat-count.leader .sentiment-score.visible{color:var(--accent)}
     html[data-theme="light"] .csat-count.leader .sentiment-score.visible{color:var(--accent)}
-    .csat-trend{display:flex;flex-direction:column;align-items:flex-end;gap:8px;padding-top:6px;margin-left:auto}
-    .csat-trend canvas{width:110px;height:64px;max-width:100%;border-radius:12px;border:1px solid var(--line);background:rgba(255,255,255,.04)}
-    .csat-trend span{font-size:.75rem;color:var(--muted);text-transform:uppercase;letter-spacing:.08em}
     .csat-footer{display:flex;flex-direction:column;align-items:flex-start;margin-top:0;gap:10px;width:100%}
     .csat-footer-primary{display:flex;align-items:center;gap:16px;flex-wrap:wrap}
     .csat-footer .muted{text-align:left;max-width:260px}
@@ -203,11 +199,8 @@
       .csat-face-wrap{width:100%}
       .csat-rate-stars{justify-content:center}
       .csat-footer-primary{justify-content:center}
-      .csat-body{grid-template-columns:1fr;justify-items:center}
-      .csat-baseline{width:100%}
+      .csat-insights{align-items:center}
       .csat-counts{width:100%}
-      .csat-trend{width:100%;align-items:center}
-      .csat-trend canvas{width:180px}
     }
     html[data-theme="light"] .csat-average{color:var(--ink-light)}
     html[data-theme="light"] .csat-rate-stars{background:linear-gradient(135deg,rgba(10,14,26,.04),rgba(10,14,26,.02));border-color:var(--line-light)}
@@ -215,8 +208,6 @@
     html[data-theme="light"] .csat-star-btn.active,html[data-theme="light"] .csat-star-btn:hover,html[data-theme="light"] .csat-star-btn:focus-visible{background:var(--accent);color:#fff}
     html[data-theme="light"] .csat-count{background:#eef1fb;border-color:var(--line-light);color:var(--ink-light)}
     html[data-theme="light"] .csat-count.leader{box-shadow:var(--shadow-light)}
-    html[data-theme="light"] .csat-trend canvas{background:rgba(10,14,26,.05);border-color:var(--line-light)}
-    html[data-theme="light"] .csat-trend span{color:var(--muted-light)}
     .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
     .counter{margin-bottom:8px;font-size:.9rem;text-align:left;line-height:1.4}
     .counter div{display:flex;justify-content:space-between}
@@ -485,24 +476,19 @@
                     <span id="csatVotesLabel" data-en="votes" data-es="votos">votes</span>
                   </div>
                 </div>
-                <div class="csat-counts" id="csatCounts" aria-live="polite">
-                  <div class="csat-count" data-val="5" data-label-en="Delighted" data-label-es="Encantado">
-                    <span class="sentiment"><span aria-hidden="true">🤩</span><span class="sentiment-score"></span></span>
-                  </div>
-                  <div class="csat-count" data-val="3" data-label-en="Neutral" data-label-es="Neutral">
-                    <span class="sentiment"><span aria-hidden="true">😐</span><span class="sentiment-score"></span></span>
-                  </div>
-                  <div class="csat-count" data-val="2" data-label-en="Unhappy" data-label-es="Insatisfecho">
-                    <span class="sentiment"><span aria-hidden="true">🙁</span><span class="sentiment-score"></span></span>
-                  </div>
-                </div>
-                <div class="muted" data-en="Keep delighting guests." data-es="Sigue encantando a los clientes.">Keep delighting guests.</div>
               </div>
             </div>
-            <div class="csat-body">
-              <div class="csat-trend">
-                <canvas id="csatTrend" width="110" height="64" role="img" aria-label="Customer satisfaction trend"></canvas>
-                <span class="muted" data-en="Trend" data-es="Tendencia">Trend</span>
+            <div class="csat-insights">
+              <div class="csat-counts" id="csatCounts" aria-live="polite">
+                <div class="csat-count" data-val="5" data-label-en="Delighted" data-label-es="Encantado">
+                  <span class="sentiment"><span aria-hidden="true">🤩</span><span class="sentiment-score"></span></span>
+                </div>
+                <div class="csat-count" data-val="3" data-label-en="Neutral" data-label-es="Neutral">
+                  <span class="sentiment"><span aria-hidden="true">😐</span><span class="sentiment-score"></span></span>
+                </div>
+                <div class="csat-count" data-val="2" data-label-en="Unhappy" data-label-es="Insatisfecho">
+                  <span class="sentiment"><span aria-hidden="true">🙁</span><span class="sentiment-score"></span></span>
+                </div>
               </div>
             </div>
           </div>
@@ -1258,7 +1244,6 @@
     function syncTheme(){
       document.documentElement.setAttribute('data-theme', theme);
       $('#themeBtn').textContent = theme==='light' ? t('Dark','Oscuro') : t('Light','Claro');
-      if(typeof window.renderCsatTrend==='function') window.renderCsatTrend();
     }
     function scrollByCards(d){ const c=track.querySelector('.product'); const dx=c?(c.getBoundingClientRect().width+16):300; track.scrollBy({left:d*dx,behavior:'smooth'}); }
 
@@ -1341,7 +1326,6 @@
       const moods=['😞','🙁','😐','😄','🤩'];
       const countWrap=document.getElementById('csatCounts');
       let countNodes=countWrap?Array.from(countWrap.querySelectorAll('.csat-count')):[];
-      const trendCanvas=document.getElementById('csatTrend');
       let counts=[0,0,0,0,0];
       const STORAGE_KEY='csatCounts';
 
@@ -1366,59 +1350,6 @@
           });
         }
       }
-
-      const renderTrend=()=>{
-        if(!trendCanvas) return;
-        const ctx=trendCanvas.getContext('2d');
-        if(!ctx) return;
-        const dpr=window.devicePixelRatio||1;
-        const cssW=trendCanvas.clientWidth||trendCanvas.width||110;
-        const cssH=trendCanvas.clientHeight||trendCanvas.height||64;
-        const width=Math.round(cssW*dpr);
-        const height=Math.round(cssH*dpr);
-        if(trendCanvas.width!==width||trendCanvas.height!==height){
-          trendCanvas.width=width;
-          trendCanvas.height=height;
-        }
-        ctx.clearRect(0,0,width,height);
-        const values=[counts[4],counts[3],counts[2],counts[1],counts[0]];
-        const maxVal=Math.max(...values,1);
-        const padding=Math.round(8*dpr);
-        const innerW=width-padding*2;
-        const innerH=height-padding*2;
-        const step=values.length>1?innerW/(values.length-1):innerW;
-        const isLight=document.documentElement.getAttribute('data-theme')==='light';
-        const accent=(getComputedStyle(document.documentElement).getPropertyValue('--accent')||'#6f7dff').trim()||'#6f7dff';
-        const axisColor=isLight?'rgba(10,14,26,.18)':'rgba(255,255,255,.2)';
-
-        ctx.lineWidth=1*dpr;
-        ctx.strokeStyle=axisColor;
-        ctx.beginPath();
-        ctx.moveTo(padding,height-padding);
-        ctx.lineTo(width-padding,height-padding);
-        ctx.stroke();
-
-        ctx.strokeStyle=accent;
-        ctx.lineWidth=2*dpr;
-        ctx.beginPath();
-        values.forEach((val,idx)=>{
-          const ratio=maxVal?val/maxVal:0;
-          const x=padding+(step*idx);
-          const y=padding+(innerH - ratio*innerH);
-          if(idx===0) ctx.moveTo(x,y); else ctx.lineTo(x,y);
-        });
-        ctx.stroke();
-
-        ctx.fillStyle=accent;
-        values.forEach((val,idx)=>{
-          const ratio=maxVal?val/maxVal:0;
-          const x=padding+(step*idx);
-          const y=padding+(innerH - ratio*innerH);
-          ctx.beginPath();
-          ctx.arc(x,y,2.5*dpr,0,Math.PI*2);
-          ctx.fill();
-        });
-      };
 
       const getLeaderRating=()=>{
         let bestIdx=-1;
@@ -1474,12 +1405,10 @@
             (votesLabel.dataset.en||votesLabel.textContent);
           votesLabel.textContent=label;
         }
-        renderTrend();
         if(!rating) paint(0);
       };
 
       window.updateCsatCountsUI=updateCountsUI;
-      window.renderCsatTrend=renderTrend;
 
       const persistCounts=()=>{
         try{ localStorage.setItem(STORAGE_KEY, JSON.stringify(counts)); }
@@ -1676,7 +1605,6 @@
 
       paint(0);
       updateCountsUI();
-      window.addEventListener('resize',renderTrend);
 
       (async()=>{
         const endpoints=orderedEndpoints();


### PR DESCRIPTION
## Summary
- remove the CSAT trend canvas and success message copy while keeping the rating controls intact
- rebalance the customer satisfaction card so the sentiment counters occupy their own column with equal-width tiles and align the KPI cards with responsive widths
- prune the unused rendering script tied to the deleted trend canvas

## Testing
- no tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d4c2ace0d4832ba725c2fe9a8a9169