### PR TITLE
Reposition CSAT controls and stack emoji column

### DIFF
--- a/index.html
+++ b/index.html
@@ -197,8 +197,7 @@
     }
     .kpi{padding:16px;text-align:center}
     .kpi h4{margin:6px 0 8px 0}
-    .csat{display:grid;grid-template-columns:minmax(200px,240px) 1fr;align-items:stretch;gap:24px;width:100%}
-    @media (max-width:900px){.csat{grid-template-columns:1fr;}}
+    .csat{display:flex;flex-direction:column;justify-content:space-between;gap:24px;width:100%;height:100%}
     .csat-hero{display:flex;flex-direction:column;align-items:flex-start;gap:14px;width:100%}
     #csatScore{font-weight:700;font-variant-numeric:tabular-nums;font-size:1.1rem;letter-spacing:.02em;margin-bottom:6px;color:var(--muted)}
     html[data-theme="light"] #csatScore{color:var(--muted-light)}
@@ -219,7 +218,7 @@
     .csat-hero-summary{display:flex;align-items:flex-start;gap:16px}
     .csat-face{font-size:44px;margin:0}
     .csat-face-wrap{display:flex;flex-direction:column;align-items:center;gap:12px}
-    .csat-emoji-strip{display:flex;gap:12px;justify-content:center;width:100%;margin-top:2px}
+    .csat-emoji-strip{display:flex;flex-direction:column;gap:12px;justify-content:center;align-items:center;width:100%;margin-top:2px}
     .csat-emoji{font-size:28px;filter:grayscale(.55);opacity:.6;transition:transform .2s ease,opacity .2s ease,filter .2s ease}
     .csat-emoji.active{filter:none;opacity:1;transform:scale(1.08)}
     html[data-theme="light"] .csat-emoji{filter:grayscale(.45);opacity:.55}
@@ -232,8 +231,7 @@
     .csat-star-btn{all:unset;cursor:pointer;width:38px;height:38px;border-radius:50%;display:grid;place-items:center;font-size:18px;font-weight:700;color:var(--muted);background:var(--chip);border:1px solid var(--line);transition:transform .2s ease,box-shadow .25s ease,background .25s ease,color .25s ease;opacity:.7}
     .csat-star-btn:hover,.csat-star-btn:focus-visible{transform:translateY(-2px);background:var(--accent);color:#fff;box-shadow:var(--shadow)}
     .csat-star-btn.active{background:var(--accent);color:#fff;box-shadow:var(--shadow);opacity:1}
-    .csat-insights{display:flex;flex-direction:column;gap:16px;width:100%;align-items:stretch}
-    .csat-footer{display:flex;flex-direction:column;align-items:flex-start;margin-top:12px;gap:10px;width:100%}
+    .csat-footer{display:flex;flex-direction:column;align-items:flex-start;margin-top:auto;gap:10px;width:100%}
     .csat-footer-primary{display:flex;align-items:center;gap:16px;flex-wrap:wrap}
     .csat-footer .muted{text-align:left;max-width:260px}
     @media (max-width:900px){
@@ -241,8 +239,8 @@
       .csat-hero-summary{flex-direction:column;align-items:center}
       .csat-face-wrap{width:100%}
       .csat-rate-stars{justify-content:center}
+      .csat-footer{align-items:center;text-align:center}
       .csat-footer-primary{justify-content:center}
-      .csat-insights{align-items:center}
     }
     html[data-theme="light"] .csat-average{color:var(--ink-light)}
     html[data-theme="light"] .csat-rate-stars{background:linear-gradient(135deg,rgba(10,14,26,.04),rgba(10,14,26,.02));border-color:var(--line-light)}
@@ -515,17 +513,15 @@
                 </div>
               </div>
             </div>
-            <div class="csat-insights">
-              <div class="csat-footer">
-                <div class="csat-footer-primary" aria-live="polite">
-                  <button class="btn" id="rateBtn" data-en="Rate" data-es="Calificar">Rate</button>
-                  <div class="csat-average">
-                    <span id="csatAverageValue">0.00</span><span>/5</span>
-                  </div>
-                  <div class="csat-votes">
-                    <span id="csatTotalVotes">0</span>
-                    <span id="csatVotesLabel" data-en="votes" data-es="votos">votes</span>
-                  </div>
+            <div class="csat-footer">
+              <div class="csat-footer-primary" aria-live="polite">
+                <button class="btn" id="rateBtn" data-en="Rate" data-es="Calificar">Rate</button>
+                <div class="csat-average">
+                  <span id="csatAverageValue">0.00</span><span>/5</span>
+                </div>
+                <div class="csat-votes">
+                  <span id="csatTotalVotes">0</span>
+                  <span id="csatVotesLabel" data-en="votes" data-es="votos">votes</span>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- restack the customer satisfaction emoji strip vertically for clearer sentiment ordering
- move the rate/average/votes controls to the base of the CSAT card and flex the layout to keep them anchored

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d5073fdbdc832b9057486ec8986bc2