### PR TITLE
Refine CSAT callout styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,8 +248,8 @@
       margin-left:auto;
       padding:14px 18px;
       border-radius:16px;
-      background:linear-gradient(135deg,rgba(30,169,122,.18),rgba(30,169,122,.42));
-      border:1px solid rgba(30,169,122,.55);
+      background:rgba(255,255,255,.04);
+      border:1px solid var(--line);
       min-width:180px;
       min-height:0;
       box-shadow:var(--shadow);
@@ -290,8 +290,8 @@
     html[data-theme="light"] .csat-rate-note{color:var(--muted-light)}
     html[data-theme="light"] .csat-callout-meta{color:var(--ink-light)}
     html[data-theme="light"] .csat-rate-callout{
-      background:linear-gradient(135deg,rgba(30,169,122,.12),rgba(30,169,122,.25));
-      border-color:rgba(30,169,122,.45);
+      background:rgba(10,14,26,.04);
+      border-color:var(--line-light);
       box-shadow:var(--shadow-light);
     }
     @media (max-width:900px){


### PR DESCRIPTION
## Summary
- replace the green gradient callout styling with the standard card treatment to remove the bright green rectangle
- align light theme styling for the customer satisfaction callout with the neutral surface palette

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d63e2d63bc832b8f91f2e9e4b17785