### PR TITLE
Reposition customer satisfaction rating callout

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,31 +243,32 @@
     html[data-theme="light"] .sentiment-score.zero{color:var(--muted-light)}
     .csat-hero-summary{display:flex;align-items:flex-start;gap:16px}
     .csat-face-wrap{display:flex;flex-direction:column;align-items:flex-start;gap:12px;width:100%}
-    .csat-rate-row{display:flex;align-items:center;gap:16px;width:100%}
+    .csat-rate-row{display:flex;align-items:center;gap:16px;width:100%;flex-wrap:wrap}
     .csat-rate-row .csat-rate-stars{flex:1;min-width:0}
     .csat-sentiment{font-weight:700;font-size:1.05rem;letter-spacing:.01em;display:flex;align-items:center;gap:10px;text-align:left}
     #csatSentiment{display:inline-flex;align-items:center;gap:10px;transition:font-size .3s ease;font-size:1.15rem}
     html[data-theme="light"] .csat-sentiment{color:var(--ink-light)}
     .csat-rate-callout{
       display:flex;
-      flex-direction:column;
       align-items:center;
-      justify-content:center;
-      gap:12px;
-      margin-left:auto;
+      justify-content:space-between;
+      gap:20px;
+      margin:12px 0 0;
       padding:14px 18px;
       border-radius:16px;
       background:rgba(255,255,255,.04);
       border:1px solid var(--line);
-      min-width:180px;
+      min-width:0;
       min-height:0;
       box-shadow:var(--shadow);
-      text-align:center;
+      text-align:left;
+      width:100%;
     }
-    .csat-callout-stats{display:flex;flex-direction:column;align-items:center;gap:6px}
-    .csat-callout-meta{display:flex;align-items:center;gap:6px;font-size:.95rem;color:var(--ink);font-weight:600}
+    .csat-callout-stats{display:flex;flex-direction:column;align-items:flex-start;gap:6px}
+    .csat-callout-meta{display:flex;align-items:center;gap:6px;font-size:.95rem;color:var(--ink);font-weight:600;justify-content:flex-start}
+    .csat-rate-callout .btn{margin-left:auto}
     .csat-callout-meta span{font-variant-numeric:tabular-nums}
-    .csat-rate-callout .btn{min-width:0;padding:8px 20px;font-size:13px;justify-content:center}
+    .csat-rate-callout .btn{min-width:0;padding:10px 22px;font-size:13px;justify-content:center}
     .csat-rate-note{font-size:.85rem;color:var(--muted);text-align:left;max-width:320px;line-height:1.4;margin:0}
     .csat-average{display:flex;align-items:baseline;gap:8px;color:var(--ink);font-size:2.6rem;font-weight:800;line-height:1}
     .csat-average span{font-variant-numeric:tabular-nums}
@@ -314,7 +315,10 @@
       .csat-face-wrap{width:100%;align-items:center}
       .csat-rate-stars{justify-content:center}
       .csat-rate-row{flex-direction:column;align-items:center;gap:12px}
-      .csat-rate-callout{margin-left:0;width:100%;max-width:260px}
+      .csat-rate-callout{margin-left:0;width:100%;max-width:360px;text-align:center;flex-direction:column;align-items:center}
+      .csat-callout-stats{align-items:center}
+      .csat-callout-meta{justify-content:center}
+      .csat-rate-callout .btn{margin-left:0;width:100%}
       .csat-rate-note{text-align:center}
       .csat-footer{align-items:center;text-align:center}
     }
@@ -620,18 +624,18 @@
                       <button type="button" class="csat-star-btn" aria-label="4 stars" data-val="4">★</button>
                       <button type="button" class="csat-star-btn" aria-label="5 stars" data-val="5">★</button>
                     </div>
-                    <div class="csat-rate-callout">
-                      <div class="csat-callout-stats" aria-live="polite">
-                        <div class="csat-average">
-                          <span id="csatAverageValue">0.00</span><span>/5</span>
-                        </div>
-                        <div class="csat-callout-meta">
-                          <span id="csatTotalVotes">0</span>
-                          <span id="csatVotesLabel" data-en="votes" data-es="votos">votes</span>
-                        </div>
+                  </div>
+                  <div class="csat-rate-callout">
+                    <div class="csat-callout-stats" aria-live="polite">
+                      <div class="csat-average">
+                        <span id="csatAverageValue">0.00</span><span>/5</span>
                       </div>
-                      <button class="btn" id="rateBtn" data-en="Rate" data-es="Calificar">Rate</button>
+                      <div class="csat-callout-meta">
+                        <span id="csatTotalVotes">0</span>
+                        <span id="csatVotesLabel" data-en="votes" data-es="votos">votes</span>
+                      </div>
                     </div>
+                    <button class="btn" id="rateBtn" data-en="Rate" data-es="Calificar">Rate</button>
                   </div>
                   <p class="csat-rate-note" data-en="Share your experience to keep this score strong." data-es="Comparte tu experiencia para mantener este puntaje.">
                     Share your experience to keep this score strong.


### PR DESCRIPTION
## Summary
- move the customer satisfaction average and Rate button into a dedicated callout beneath the star controls for clearer hierarchy
- update desktop and mobile styling so the callout stretches full width, keeps the button aligned, and centers correctly on smaller screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d651edbefc832b9f6fcce68685e4da