### PR TITLE
Adjust CSAT note positioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,7 +243,7 @@
     html[data-theme="light"] .sentiment-score.visible{color:var(--ink-light)}
     html[data-theme="light"] .sentiment-score.zero{color:var(--muted-light)}
     .csat-hero-summary{display:flex;align-items:center;justify-content:center;gap:16px}
-    .csat-face-wrap{display:flex;flex-direction:column;align-items:center;gap:12px;width:100%}
+    .csat-face-wrap{display:flex;flex-direction:column;align-items:center;gap:12px;width:100%;flex:1}
     .csat-rate-row{display:flex;align-items:center;justify-content:center;gap:16px;width:100%;flex-wrap:wrap}
     .csat-rate-row .csat-rate-stars{flex:1;min-width:0}
     .csat-sentiment{font-weight:700;font-size:1.05rem;letter-spacing:.01em;display:flex;align-items:center;gap:10px;text-align:center;justify-content:center}
@@ -271,7 +271,7 @@
     .csat-callout-meta{display:flex;align-items:center;gap:6px;font-size:.95rem;color:var(--ink);font-weight:600;justify-content:center}
     .csat-callout-meta span{font-variant-numeric:tabular-nums}
     .csat-rate-callout .btn{min-width:0;padding:10px 22px;font-size:13px;justify-content:center;width:auto}
-    .csat-rate-note{font-size:.85rem;color:var(--muted);text-align:center;max-width:360px;line-height:1.4;margin:0 auto}
+    .csat-rate-note{font-size:.85rem;color:var(--muted);text-align:center;max-width:360px;line-height:1.4;margin:0 auto;margin-top:auto;padding-top:16px}
     .csat-average{display:flex;align-items:baseline;gap:8px;color:var(--ink);font-size:2.6rem;font-weight:800;line-height:1}
     .csat-average span{font-variant-numeric:tabular-nums}
     .csat-rate-stars{display:flex;align-items:center;justify-content:center;gap:8px;background:linear-gradient(135deg,rgba(255,255,255,.04),rgba(255,255,255,.01));padding:8px 12px;border-radius:16px;border:1px solid var(--line)}


### PR DESCRIPTION
## Summary
- extend the customer satisfaction face container to fill the KPI card
- push the feedback note to the bottom of the card for clearer alignment

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d67a3acb94832bab7e2389bf0f39b8