### PR TITLE
Ensure CSAT submissions forward to Apps Script

### DIFF
--- a/index.html
+++ b/index.html
@@ -1058,7 +1058,7 @@
       }
     };
 
-    const APPS_SCRIPT_URL = "";       // optional
+    const APPS_SCRIPT_URL = "https://script.google.com/macros/s/AKfycbyJ8ZBUrTnS4xsGQbXT2J7m7-dKFOTHITq6MgposYzanjYWeti-dXlpr6_0YLN8mfYevQ/exec";
 
     const WORKER_CSAT_BASE = joinWorkerPath(WORKER_CSAT_URL,'');
     const MAX_PENDING = 25;
@@ -2457,6 +2457,7 @@
           return;
         }
         if(rateBtn?.disabled) return;
+        setRateBtnBusy(true);
         let uid;
         let fp;
         if(typeof window._csatGetIds==='function'){

--- a/worker.toml
+++ b/worker.toml
@@ -4,7 +4,7 @@ compatibility_date = "2024-06-28"
 workers_dev = true
 
 [vars]
-APPS_FORWARD_URL = "https://weathered-disk-a104.distraction.workers.dev/"
+APPS_FORWARD_URL = "https://script.google.com/macros/s/AKfycbyJ8ZBUrTnS4xsGQbXT2J7m7-dKFOTHITq6MgposYzanjYWeti-dXlpr6_0YLN8mfYevQ/exec"
 PUBLIC_WORKER_BASE = "https://weathered-disk-a104.distraction.workers.dev/"
 PUBLIC_CSAT_URL = "https://weathered-disk-a104.distraction.workers.dev/csat"
 PUBLIC_SENTIMENT_BASE = "https://weathered-disk-a104.distraction.workers.dev/"


### PR DESCRIPTION
## Summary
- point the frontend to the production Apps Script endpoint so order and CSAT payloads propagate beyond the worker
- disable the rate button while a vote is being submitted to prevent duplicate requests and clarify its busy state
- align the worker configuration with the new Apps Script forwarding base URL

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d6de2b9d3c832b99c49af0c08238dc