### PR TITLE
Improve quick settings accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,10 +40,36 @@
       </p>
     </div>
     <nav aria-label="Quick settings" class="topbar__toggles">
-      <button class="toggle" id="languageEn" type="button" data-action="language" data-lang="en" aria-pressed="true">EN</button>
-      <button class="toggle" id="languageEs" type="button" data-action="language" data-lang="es" aria-pressed="false">ES</button>
-      <button class="toggle" id="themeLight" type="button" data-action="theme" data-theme="light" aria-pressed="true">☀️</button>
-      <button class="toggle" id="themeDark" type="button" data-action="theme" data-theme="dark" aria-pressed="false">🌙</button>
+      <div class="toggle-group" role="group" aria-label="Language selection">
+        <button class="toggle" id="languageEn" type="button" data-action="language" data-lang="en" aria-pressed="true">EN</button>
+        <button class="toggle" id="languageEs" type="button" data-action="language" data-lang="es" aria-pressed="false">ES</button>
+      </div>
+      <div class="toggle-group" role="group" aria-label="Theme selection">
+        <button
+          class="toggle"
+          id="themeLight"
+          type="button"
+          data-action="theme"
+          data-theme="light"
+          aria-pressed="true"
+          aria-label="Use light theme"
+          title="Use light theme"
+        >
+          ☀️
+        </button>
+        <button
+          class="toggle"
+          id="themeDark"
+          type="button"
+          data-action="theme"
+          data-theme="dark"
+          aria-pressed="false"
+          aria-label="Use dark theme"
+          title="Use dark theme"
+        >
+          🌙
+        </button>
+      </div>
     </nav>
   </header>
 

--- a/main.css
+++ b/main.css
@@ -130,7 +130,25 @@ body {
 
 .topbar__toggles {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.toggle-group {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem;
+  border-radius: 999px;
+  background: var(--surface-muted);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.2);
+}
+
+[data-theme="dark"] .toggle-group {
+  background: rgba(10, 11, 15, 0.6);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
 }
 
 .toggle {
@@ -635,6 +653,11 @@ body {
   .topbar__toggles {
     align-self: stretch;
     justify-content: space-between;
+  }
+
+  .toggle-group {
+    flex: 1 1 160px;
+    justify-content: center;
   }
 
   .panel--orders {


### PR DESCRIPTION
## Summary
- group the language and theme quick-setting buttons for clearer structure
- add accessible labelling to the theme toggles and enhance the topbar styling
- refine responsive behaviour for the grouped controls on smaller screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7eed59330832ba7249c17c57fd327