### PR TITLE
Simplify language and theme toggles

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,33 +41,25 @@
     </div>
     <nav aria-label="Quick settings" class="topbar__toggles">
       <div class="toggle-group" role="group" aria-label="Language selection">
-        <button class="toggle" id="languageEn" type="button" data-action="language" data-lang="en" aria-pressed="true">EN</button>
-        <button class="toggle" id="languageEs" type="button" data-action="language" data-lang="es" aria-pressed="false">ES</button>
+        <button
+          class="toggle-button"
+          id="languageToggle"
+          type="button"
+          aria-pressed="false"
+          aria-label="Switch to Spanish"
+        >
+          ES
+        </button>
       </div>
       <div class="toggle-group" role="group" aria-label="Theme selection">
         <button
-          class="toggle"
-          id="themeLight"
+          class="toggle-button toggle-button--theme"
+          id="themeToggle"
           type="button"
-          data-action="theme"
-          data-theme="light"
-          aria-pressed="true"
-          aria-label="Use light theme"
-          title="Use light theme"
-        >
-          ☀️
-        </button>
-        <button
-          class="toggle"
-          id="themeDark"
-          type="button"
-          data-action="theme"
-          data-theme="dark"
           aria-pressed="false"
-          aria-label="Use dark theme"
-          title="Use dark theme"
+          aria-label="Switch to dark theme"
         >
-          🌙
+          Dark
         </button>
       </div>
     </nav>

--- a/main.css
+++ b/main.css
@@ -13,30 +13,38 @@
   --surface-strong: rgba(255, 255, 255, 0.86);
   --text-main: #1f1b2c;
   --text-muted: #574f65;
-  --accent: #ff8b3d;
-  --accent-strong: #ff5b2e;
-  --background-top: #fff7e6;
-  --background-bottom: #ffe7f1;
+  --accent: #ffb347;
+  --accent-strong: #ff7f50;
+  --background-top: #fff4d4;
+  --background-middle: #ffe0f2;
+  --background-bottom: #dff6f0;
   --border-subtle: rgba(255, 255, 255, 0.6);
-  --chip-bg: rgba(255, 139, 61, 0.08);
-  --chip-text: #ff5b2e;
+  --chip-bg: rgba(255, 179, 71, 0.2);
+  --chip-text: #ff7f50;
+  --toggle-bg: rgba(255, 255, 255, 0.85);
+  --toggle-fg: var(--text-main);
+  --toggle-shadow: rgba(31, 27, 44, 0.18);
 }
 
 [data-theme="dark"] {
   color-scheme: dark;
   --shadow-soft: 0 24px 48px rgba(5, 6, 10, 0.65);
-  --surface: rgba(32, 34, 42, 0.9);
-  --surface-muted: rgba(17, 18, 23, 0.75);
-  --surface-strong: rgba(16, 17, 21, 0.95);
+  --surface: rgba(24, 25, 32, 0.92);
+  --surface-muted: rgba(12, 13, 18, 0.85);
+  --surface-strong: rgba(10, 11, 16, 0.95);
   --text-main: #f2f5ff;
   --text-muted: #b1b6cd;
   --accent: #4dd4ff;
   --accent-strong: #7ef3b3;
-  --background-top: #030509;
-  --background-bottom: #111827;
+  --background-top: #050508;
+  --background-middle: #0c0d11;
+  --background-bottom: #16171d;
   --border-subtle: rgba(126, 243, 179, 0.24);
   --chip-bg: rgba(126, 243, 179, 0.15);
   --chip-text: #7ef3b3;
+  --toggle-bg: rgba(12, 13, 18, 0.9);
+  --toggle-fg: var(--text-main);
+  --toggle-shadow: rgba(5, 6, 10, 0.55);
 }
 
 * {
@@ -46,19 +54,21 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: radial-gradient(circle at top right, rgba(255, 207, 160, 0.35), transparent 40%),
-    radial-gradient(circle at bottom left, rgba(255, 157, 220, 0.35), transparent 45%),
-    linear-gradient(180deg, var(--background-top) 0%, var(--background-bottom) 100%);
+  background: radial-gradient(circle at 12% 18%, rgba(255, 193, 134, 0.32), transparent 42%),
+    radial-gradient(circle at 88% 22%, rgba(255, 179, 213, 0.28), transparent 46%),
+    radial-gradient(circle at 18% 82%, rgba(166, 227, 199, 0.34), transparent 48%),
+    linear-gradient(165deg, var(--background-top) 0%, var(--background-middle) 48%, var(--background-bottom) 100%);
   color: var(--text-main);
   display: flex;
   flex-direction: column;
   position: relative;
+  transition: background var(--transition), color var(--transition);
 }
 
 [data-theme="dark"] body {
-  background: radial-gradient(circle at top right, rgba(77, 212, 255, 0.15), transparent 40%),
-    radial-gradient(circle at bottom left, rgba(126, 243, 179, 0.12), transparent 45%),
-    linear-gradient(180deg, var(--background-top) 0%, var(--background-bottom) 100%);
+  background: radial-gradient(circle at 10% 12%, rgba(77, 212, 255, 0.16), transparent 36%),
+    radial-gradient(circle at 90% 20%, rgba(126, 243, 179, 0.12), transparent 38%),
+    linear-gradient(175deg, var(--background-top) 0%, var(--background-middle) 40%, var(--background-bottom) 100%);
 }
 
 .skip-link {
@@ -139,38 +149,53 @@ body {
 .toggle-group {
   display: flex;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0.35rem;
-  border-radius: 999px;
-  background: var(--surface-muted);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.2);
+  gap: 0.5rem;
 }
 
-[data-theme="dark"] .toggle-group {
-  background: rgba(10, 11, 15, 0.6);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
-}
-
-.toggle {
+.toggle-button {
+  appearance: none;
   border: none;
   border-radius: 999px;
-  padding: 0.5rem 0.85rem;
+  padding: 0.6rem 1.4rem;
+  background: var(--toggle-bg);
+  color: var(--toggle-fg);
+  font: inherit;
   font-weight: 600;
-  background: var(--chip-bg);
-  color: var(--chip-text);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
   cursor: pointer;
-  transition: background var(--transition), color var(--transition), transform var(--transition);
+  box-shadow: 0 10px 22px var(--toggle-shadow);
+  transition: transform var(--transition), box-shadow var(--transition),
+    background var(--transition), color var(--transition);
 }
 
-.toggle[aria-pressed="true"] {
-  background: var(--accent);
-  color: #101319;
+.toggle-button:hover {
   transform: translateY(-1px);
+  box-shadow: 0 14px 28px var(--toggle-shadow);
 }
 
-.toggle:focus-visible {
+.toggle-button:active {
+  transform: translateY(1px);
+  box-shadow: 0 8px 18px var(--toggle-shadow);
+}
+
+.toggle-button[aria-pressed="true"] {
+  background: var(--accent-strong);
+  color: #ffffff;
+  box-shadow: 0 12px 26px rgba(255, 127, 80, 0.32);
+}
+
+[data-theme="dark"] .toggle-button[aria-pressed="true"] {
+  box-shadow: 0 12px 26px rgba(126, 243, 179, 0.24);
+}
+
+.toggle-button:focus-visible {
   outline: 2px solid var(--accent);
-  outline-offset: 2px;
+  outline-offset: 3px;
+}
+
+.toggle-button--theme {
+  margin-left: 0.5rem;
 }
 
 .page {

--- a/main.js
+++ b/main.js
@@ -10,7 +10,9 @@
   const fabPay = document.querySelector('#fabPay');
   const fabMenus = Array.from(document.querySelectorAll('.fab-menu'));
   const drawers = Array.from(document.querySelectorAll('.drawer'));
-  const toggles = Array.from(document.querySelectorAll('[data-action="theme"], [data-action="language"]'));
+  const languageToggle = document.querySelector('#languageToggle');
+  const themeToggle = document.querySelector('#themeToggle');
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
 
   const translations = {
     en: {
@@ -105,24 +107,27 @@
     const nextTheme = theme === 'dark' ? 'dark' : 'light';
     html.dataset.theme = nextTheme;
     localStorage.setItem('marxia-theme', nextTheme);
-    toggles
-      .filter((toggle) => toggle.dataset.action === 'theme')
-      .forEach((toggle) => {
-        const isActive = toggle.dataset.theme === nextTheme;
-        toggle.setAttribute('aria-pressed', String(isActive));
-      });
+    if (themeToggle) {
+      const isDark = nextTheme === 'dark';
+      themeToggle.textContent = isDark ? 'Light' : 'Dark';
+      themeToggle.setAttribute('aria-label', isDark ? 'Switch to light theme' : 'Switch to dark theme');
+      themeToggle.setAttribute('aria-pressed', String(isDark));
+    }
   };
 
   const applyLanguage = (lang) => {
     const nextLang = lang === 'es' ? 'es' : 'en';
     html.lang = nextLang;
     localStorage.setItem('marxia-lang', nextLang);
-    toggles
-      .filter((toggle) => toggle.dataset.action === 'language')
-      .forEach((toggle) => {
-        const isActive = toggle.dataset.lang === nextLang;
-        toggle.setAttribute('aria-pressed', String(isActive));
-      });
+    if (languageToggle) {
+      const isSpanish = nextLang === 'es';
+      languageToggle.textContent = isSpanish ? 'EN' : 'ES';
+      languageToggle.setAttribute(
+        'aria-label',
+        isSpanish ? 'Idioma: Español (cambiar a inglés)' : 'Language: English (switch to Spanish)'
+      );
+      languageToggle.setAttribute('aria-pressed', String(isSpanish));
+    }
 
     const dict = translations[nextLang];
     document.querySelectorAll('[data-i18n]').forEach((node) => {
@@ -151,6 +156,10 @@
     const savedLang = localStorage.getItem('marxia-lang');
     if (savedTheme) {
       applyTheme(savedTheme);
+    } else if (prefersDark) {
+      applyTheme('dark');
+    } else {
+      applyTheme('light');
     }
     if (savedLang) {
       applyLanguage(savedLang);
@@ -197,12 +206,14 @@
     const target = event.target;
     if (!(target instanceof HTMLElement)) return;
 
-    if (target.dataset.action === 'theme' && target.dataset.theme) {
-      applyTheme(target.dataset.theme);
+    if (target === themeToggle) {
+      const nextTheme = html.dataset.theme === 'dark' ? 'light' : 'dark';
+      applyTheme(nextTheme);
     }
 
-    if (target.dataset.action === 'language' && target.dataset.lang) {
-      applyLanguage(target.dataset.lang);
+    if (target === languageToggle) {
+      const nextLang = html.lang === 'es' ? 'en' : 'es';
+      applyLanguage(nextLang);
     }
 
     if (target.matches('[data-close-drawer]')) {


### PR DESCRIPTION
## Summary
- replace the pill controls with single language and theme buttons that announce their current state and next action
- refresh the light and dark backgrounds to deliver the requested summer/spring palette and deep gray night mode
- update preference handling so toggles flip text labels, sync aria attributes, and respect prefers-color-scheme on first load

## Testing
- Manual smoke test in browser

------
https://chatgpt.com/codex/tasks/task_e_68d8081be11c832bb925545090f9617c