### PR TITLE
Reflow insights layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -286,7 +286,7 @@
         <h2 id="insights-title" data-i18n="insightsTitle">Experience dashboard</h2>
         <p data-i18n="insightsSubtitle">Monitor sentiment, visitors, and online sales in real time.</p>
       </header>
-      <div class="insights__grid">
+      <div class="insights__grid insights__grid--metrics">
         <article class="panel" aria-labelledby="sentiment-title">
           <header>
             <h3 id="sentiment-title" data-i18n="sentimentTitle">End consumer sentiment</h3>
@@ -331,44 +331,44 @@
             <figcaption id="sales-stats" data-i18n="salesCaption">Today $620 · This month $18,400 · Last year $212,000</figcaption>
           </figure>
         </article>
-
-        <article class="panel panel--orders" aria-labelledby="orders-title">
-          <header>
-            <h3 id="orders-title" data-i18n="ordersTitle">Order details</h3>
-            <p class="panel__meta" data-i18n="ordersMeta">Secure checkout enabled</p>
-          </header>
-          <h4 class="order-summary__heading" data-i18n="orderItems">Selected items</h4>
-          <ul class="order-summary__items" data-summary-items aria-live="polite"></ul>
-          <p class="order-summary__empty" id="orderSummaryEmpty" data-i18n="orderSummaryEmpty">Your basket is empty. Add seasonal favorites to see them here.</p>
-          <dl class="order-summary">
-            <div>
-              <dt data-i18n="ordersSubtotal">Subtotal</dt>
-              <dd data-summary="subtotal">$0.00</dd>
-            </div>
-            <div>
-              <dt data-i18n="ordersTax">VAT 12%</dt>
-              <dd data-summary="tax">$0.00</dd>
-            </div>
-            <div>
-              <dt data-i18n="ordersDelivery">Delivery</dt>
-              <dd data-summary="delivery">$0.00</dd>
-            </div>
-            <div class="order-summary__total">
-              <dt data-i18n="ordersTotal">Total</dt>
-              <dd data-summary="total">$0.00</dd>
-            </div>
-          </dl>
-          <div class="delivery-time" role="group" aria-labelledby="delivery-title">
-            <span id="delivery-title" data-i18n="deliveryTitle">Delivery time</span>
-            <div class="delivery-time__options">
-              <button type="button" class="chip" aria-pressed="true">45 min</button>
-              <button type="button" class="chip" aria-pressed="false">1 hr</button>
-              <button type="button" class="chip" aria-pressed="false">1 hr 30 min</button>
-            </div>
-          </div>
-          <button type="button" class="button button--primary" data-i18n="checkout">Secure checkout</button>
-        </article>
       </div>
+
+      <article class="panel panel--orders" aria-labelledby="orders-title">
+        <header>
+          <h3 id="orders-title" data-i18n="ordersTitle">Order details</h3>
+          <p class="panel__meta" data-i18n="ordersMeta">Secure checkout enabled</p>
+        </header>
+        <h4 class="order-summary__heading" data-i18n="orderItems">Selected items</h4>
+        <ul class="order-summary__items" data-summary-items aria-live="polite"></ul>
+        <p class="order-summary__empty" id="orderSummaryEmpty" data-i18n="orderSummaryEmpty">Your basket is empty. Add seasonal favorites to see them here.</p>
+        <dl class="order-summary">
+          <div>
+            <dt data-i18n="ordersSubtotal">Subtotal</dt>
+            <dd data-summary="subtotal">$0.00</dd>
+          </div>
+          <div>
+            <dt data-i18n="ordersTax">VAT 12%</dt>
+            <dd data-summary="tax">$0.00</dd>
+          </div>
+          <div>
+            <dt data-i18n="ordersDelivery">Delivery</dt>
+            <dd data-summary="delivery">$0.00</dd>
+          </div>
+          <div class="order-summary__total">
+            <dt data-i18n="ordersTotal">Total</dt>
+            <dd data-summary="total">$0.00</dd>
+          </div>
+        </dl>
+        <div class="delivery-time" role="group" aria-labelledby="delivery-title">
+          <span id="delivery-title" data-i18n="deliveryTitle">Delivery time</span>
+          <div class="delivery-time__options">
+            <button type="button" class="chip" aria-pressed="true">45 min</button>
+            <button type="button" class="chip" aria-pressed="false">1 hr</button>
+            <button type="button" class="chip" aria-pressed="false">1 hr 30 min</button>
+          </div>
+        </div>
+        <button type="button" class="button button--primary" data-i18n="checkout">Secure checkout</button>
+      </article>
     </section>
 
     <section class="contact" aria-labelledby="contact-title">

--- a/main.css
+++ b/main.css
@@ -477,8 +477,12 @@ body {
 
 .insights__grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: 1.5rem;
+}
+
+.insights__grid--metrics {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  width: 100%;
 }
 
 .panel {
@@ -570,12 +574,12 @@ body {
 }
 
 .panel--orders {
-  justify-self: center;
-  max-width: 420px;
+  max-width: clamp(320px, 100%, 640px);
   width: 100%;
   text-align: center;
   display: grid;
   gap: 1.25rem;
+  margin-inline: auto;
 }
 
 .order-summary__heading {


### PR DESCRIPTION
## Summary
- move the order details panel outside the insights metrics grid so it appears beneath the three dashboard cards
- add a dedicated metrics grid modifier and update order panel sizing to let the three insight cards span the full width

## Testing
- Manually verified layout in browser

------
https://chatgpt.com/codex/tasks/task_e_68d8100c823c832baa7765ac7fd8ac43