### PR TITLE
Improve floating contact button contrast

### DIFF
--- a/main.css
+++ b/main.css
@@ -709,7 +709,7 @@ body {
 }
 
 .contact a {
-  color: var(--accent);
+  color: var(--accent-strong);
   font-weight: 600;
   text-decoration: none;
 }
@@ -737,9 +737,9 @@ body {
 
 .fab,
 .fab-option {
-  background: var(--surface);
-  color: var(--text-main);
-  border: none;
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
+  color: #101319;
+  border: 1px solid rgba(16, 19, 25, 0.1);
   border-radius: 50%;
   width: 54px;
   height: 54px;
@@ -758,6 +758,13 @@ body {
   transform: translateY(-2px);
   filter: brightness(1.05);
   outline: none;
+}
+
+[data-theme="dark"] .fab,
+[data-theme="dark"] .fab-option {
+  background: var(--surface-strong);
+  color: var(--text-main);
+  border: 1px solid rgba(242, 245, 255, 0.08);
 }
 
 .fab[aria-pressed="true"] {


### PR DESCRIPTION
## Summary
- darken contact link color for better readability against the footer background
- apply a vibrant gradient and subtle border to floating contact action buttons to improve contrast in light mode
- ensure dark mode buttons retain legibility with dedicated styling

## Testing
- Manual visual inspection in browser

------
https://chatgpt.com/codex/tasks/task_e_68d81249ac60832ba75171b290543f46