### PR TITLE
Adjust order panel layout

### DIFF
--- a/main.css
+++ b/main.css
@@ -515,6 +515,10 @@ body {
   box-shadow: var(--shadow-soft);
 }
 
+.panel--orders {
+  grid-column: 1 / -1;
+}
+
 .panel header h3 {
   margin: 0;
   font-size: 1.2rem;


### PR DESCRIPTION
## Summary
- span the order details panel across the full width of the insights grid so it sits below the other dashboard cards

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8126903c4832bbb8d5b7dc9982eff