### PR TITLE
Improve responsive menu accordion and delivery info placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
         <p class="tagline" data-i18n="tagline">Breakfasts, pastries, and delivery throughout Guayaquil.</p>
         <div class="hero__cta">
           <button id="orderButton" class="cta" type="button" data-i18n="orderNow">Order now</button>
-          <p class="hero__promise" data-i18n="promise">Fresh flavors, curated menus, secure checkout.</p>
+          <p class="hero__promise" data-i18n="promise">Fresh flavors every morning.</p>
         </div>
       </div>
     </section>
@@ -83,16 +83,16 @@
           <button
             class="accordion__trigger"
             type="button"
-            aria-expanded="true"
+            aria-expanded="false"
             aria-controls="seasonalFavorites"
             id="order-title"
           >
-            <span data-i18n="orderTitle">Our seasonal best sellers</span>
+            <span data-i18n="orderTitle">Our menu</span>
             <span class="accordion__icon" aria-hidden="true">▾</span>
           </button>
         </h2>
-        <div class="accordion__content" id="seasonalFavorites" role="region" aria-labelledby="order-title">
-          <p class="accordion__description" data-i18n="orderSubtitle">Tap on your favorites to build the perfect breakfast spread.</p>
+        <div class="accordion__content" id="seasonalFavorites" role="region" aria-labelledby="order-title" hidden>
+          <p class="accordion__description" data-i18n="orderSubtitle">Tap to explore our handcrafted favorites.</p>
           <div class="product-carousel" data-carousel>
             <button
               class="carousel__control carousel__control--prev"
@@ -276,7 +276,7 @@
     <section class="insights" aria-labelledby="insights-title">
       <header class="section-header">
         <h2 id="insights-title" data-i18n="insightsTitle">Experience dashboard</h2>
-        <p data-i18n="insightsSubtitle">Monitor sentiment, visitors, and online sales in real time.</p>
+        <p data-i18n="insightsSubtitle"></p>
       </header>
       <div class="insights__grid insights__grid--metrics">
         <article class="panel" aria-labelledby="sentiment-title">
@@ -325,6 +325,12 @@
         </article>
       </div>
 
+      <article class="panel panel--contact" aria-labelledby="contact-title">
+        <h3 id="contact-title" data-i18n="contactTitle">We deliver to</h3>
+        <p data-i18n="contactAreas">Saucés · Alborada · Guayacanes · Tarazana · Brisas del Río</p>
+        <p data-i18n="contactWhatsApp">WhatsApp <a href="https://wa.me/593987654321">+593 958 741 463</a></p>
+      </article>
+
       <article class="panel panel--orders" aria-labelledby="orders-title">
         <header>
           <h3 id="orders-title" data-i18n="ordersTitle">Order details</h3>
@@ -332,7 +338,7 @@
         </header>
         <h4 class="order-summary__heading" data-i18n="orderItems">Selected items</h4>
         <ul class="order-summary__items" data-summary-items aria-live="polite"></ul>
-        <p class="order-summary__empty" id="orderSummaryEmpty" data-i18n="orderSummaryEmpty">Your basket is empty. Add seasonal favorites to see them here.</p>
+        <p class="order-summary__empty" id="orderSummaryEmpty" data-i18n="orderSummaryEmpty">Your basket is empty. Add menu favorites to see them here.</p>
         <dl class="order-summary">
           <div>
             <dt data-i18n="ordersSubtotal">Subtotal</dt>
@@ -363,11 +369,6 @@
       </article>
     </section>
 
-    <section class="contact" aria-labelledby="contact-title">
-      <h2 id="contact-title" data-i18n="contactTitle">We deliver to</h2>
-      <p data-i18n="contactAreas">Saucés · Alborada · Guayacanes · Tarazana · Brisas del Río</p>
-      <p data-i18n="contactWhatsApp">WhatsApp <a href="https://wa.me/593987654321">+593 958 741 463</a></p>
-    </section>
   </main>
 
   <aside class="fab-group" aria-label="Floating actions">
@@ -411,7 +412,7 @@
       <div class="drawer__body">
         <p data-i18n="paySecurity">Secure payments protected with PCI DSS compliant encryption.</p>
         <ul class="payment-list" data-payment-items aria-live="polite"></ul>
-        <p class="payment-list__empty" data-payment-empty data-i18n="orderSummaryEmpty">Your basket is empty. Add seasonal favorites to see them here.</p>
+        <p class="payment-list__empty" data-payment-empty data-i18n="orderSummaryEmpty">Your basket is empty. Add menu favorites to see them here.</p>
         <p class="payment-list__total"><strong data-i18n="ordersTotal">Total</strong>: <span data-payment-total>$0.00</span></p>
         <button type="button" class="button button--primary" data-i18n="payNow">Pay now</button>
       </div>

--- a/main.css
+++ b/main.css
@@ -284,16 +284,28 @@ body {
   color: var(--text-muted);
 }
 
+.section-header p:empty {
+  display: none;
+}
+
 .order {
   background: var(--surface);
   border-radius: var(--radius-lg);
   padding: clamp(2rem, 4vw, 3rem);
   box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+  justify-items: center;
+  text-align: center;
+  width: min(100%, 960px);
+  margin-inline: auto;
 }
 
 .accordion {
   display: grid;
   gap: 1.5rem;
+  width: min(100%, 960px);
+  margin-inline: auto;
 }
 
 .accordion__title {
@@ -302,10 +314,10 @@ body {
 
 .accordion__trigger {
   width: 100%;
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
+  justify-content: center;
+  gap: 0.75rem;
   border: none;
   background: var(--surface-strong);
   color: inherit;
@@ -319,7 +331,7 @@ body {
 }
 
 .accordion__trigger span:first-child {
-  flex: 1;
+  flex: 0 1 auto;
   text-align: center;
 }
 
@@ -343,6 +355,7 @@ body {
   color: var(--chip-text);
   font-size: 1.25rem;
   transition: transform var(--transition);
+  margin-left: 0;
 }
 
 .accordion__content {
@@ -508,11 +521,14 @@ body {
 .insights__grid {
   display: grid;
   gap: 1.5rem;
+  width: min(100%, 1200px);
+  margin-inline: auto;
 }
 
 .insights__grid--metrics {
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   width: 100%;
+  justify-items: center;
 }
 
 .panel {
@@ -614,6 +630,29 @@ body {
   display: grid;
   gap: 1.25rem;
   margin-inline: auto;
+}
+
+.panel--contact {
+  max-width: clamp(320px, 100%, 520px);
+  width: 100%;
+  text-align: center;
+  margin-inline: auto;
+}
+
+.panel--contact p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.panel--contact a {
+  color: var(--accent-strong);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.panel--contact a:hover,
+.panel--contact a:focus-visible {
+  text-decoration: underline;
 }
 
 .order-summary__heading {

--- a/main.js
+++ b/main.js
@@ -17,12 +17,12 @@
     en: {
       headline: 'Marxia Café y Bocaditos',
       tagline: 'Breakfasts, pastries, and delivery throughout Guayaquil.',
-      promise: 'Fresh flavors, curated menus, secure checkout.',
+      promise: 'Fresh flavors every morning.',
       orderNow: 'Order now',
-      orderTitle: 'Our seasonal best sellers',
-      orderSubtitle: 'Tap on your favorites to build the perfect breakfast spread.',
+      orderTitle: 'Our menu',
+      orderSubtitle: 'Tap to explore our handcrafted favorites.',
       insightsTitle: 'Experience dashboard',
-      insightsSubtitle: 'Monitor sentiment, visitors, and online sales in real time.',
+      insightsSubtitle: '',
       sentimentTitle: 'End consumer sentiment',
       sentimentUpdated: 'Updated every 30 minutes',
       sentimentScore: 'Average rating',
@@ -40,7 +40,7 @@
       ordersDelivery: 'Delivery',
       ordersTotal: 'Total',
       orderItems: 'Selected items',
-      orderSummaryEmpty: 'Your basket is empty. Add seasonal favorites to see them here.',
+      orderSummaryEmpty: 'Your basket is empty. Add menu favorites to see them here.',
       deliveryTitle: 'Delivery time',
       checkout: 'Secure checkout',
       carouselPrev: 'Previous favorites',
@@ -64,12 +64,12 @@
     es: {
       headline: 'Marxia Café y Bocaditos',
       tagline: 'Desayunos, bocaditos y envíos en todo Guayaquil.',
-      promise: 'Sabores frescos, menús curados y pago seguro.',
+      promise: 'Sabores frescos cada mañana.',
       orderNow: 'Ordenar ahora',
-      orderTitle: 'Nuestros favoritos de temporada',
-      orderSubtitle: 'Selecciona tus preferidos para armar el desayuno ideal.',
+      orderTitle: 'Nuestro menú',
+      orderSubtitle: 'Explora nuestros favoritos artesanales.',
       insightsTitle: 'Panel de experiencia',
-      insightsSubtitle: 'Monitoriza el sentimiento, visitantes y ventas online en tiempo real.',
+      insightsSubtitle: '',
       sentimentTitle: 'Sentimiento del consumidor final',
       sentimentUpdated: 'Actualizado cada 30 minutos',
       sentimentScore: 'Calificación promedio',
@@ -87,7 +87,7 @@
       ordersDelivery: 'Envío',
       ordersTotal: 'Total',
       orderItems: 'Artículos seleccionados',
-      orderSummaryEmpty: 'Tu pedido está vacío. Agrega favoritos de temporada para verlos aquí.',
+      orderSummaryEmpty: 'Tu pedido está vacío. Agrega favoritos del menú para verlos aquí.',
       deliveryTitle: 'Tiempo de entrega',
       checkout: 'Checkout seguro',
       carouselPrev: 'Favoritos anteriores',
@@ -323,7 +323,7 @@
       const key = node.getAttribute('data-i18n');
       if (!key) return;
       const translation = dict[key];
-      if (!translation) return;
+      if (translation === undefined) return;
 
       const attrTarget = node.getAttribute('data-i18n-attr');
       if (attrTarget) {
@@ -341,7 +341,11 @@
       }
 
       if (node.querySelector('a') && key === 'contactWhatsApp') {
-        node.childNodes[0].textContent = `${translation} `;
+        const prefixNode = node.childNodes[0];
+        if (prefixNode) {
+          const prefixText = translation ? `${translation} ` : '';
+          prefixNode.textContent = prefixText;
+        }
       } else {
         node.textContent = translation;
       }


### PR DESCRIPTION
## Summary
- center the menu accordion under a renamed "Our menu" trigger that starts collapsed for better responsiveness
- relocate the delivery coverage details ahead of the order summary inside the insights section with consistent panel styling
- refresh hero and translation strings, and allow empty subtitles in the locale helper so messaging can be hidden when needed

## Testing
- Manual UI verification

------
https://chatgpt.com/codex/tasks/task_e_68d818423acc832b801799bd5e60fcc1