### PR TITLE
Fix mobile menu carousel rendering

### DIFF
--- a/main.js
+++ b/main.js
@@ -735,6 +735,12 @@
   if (accordionTrigger && accordionContent) {
     const expanded = accordionTrigger.getAttribute('aria-expanded') === 'true';
     accordionContent.hidden = !expanded;
+    const refreshCarouselLayout = () => {
+      window.requestAnimationFrame(() => {
+        updateCarousel();
+      });
+    };
+
     accordionTrigger.addEventListener('click', () => {
       const isExpanded = accordionTrigger.getAttribute('aria-expanded') === 'true';
       const nextExpanded = !isExpanded;
@@ -742,9 +748,13 @@
       accordionContent.hidden = !nextExpanded;
       if (nextExpanded) {
         currentSlideIndex = 0;
-        updateCarousel();
+        refreshCarouselLayout();
       }
     });
+
+    if (!accordionContent.hidden) {
+      refreshCarouselLayout();
+    }
   }
 
   if (carouselPrev) {


### PR DESCRIPTION
## Summary
- defer the carousel layout update until after the accordion is visible to avoid zero-width measurements
- trigger a layout refresh on load when the menu section starts expanded

## Testing
- Manual verification on a mobile viewport

------
https://chatgpt.com/codex/tasks/task_e_68d89a86a784832ba3439276abeb3e41