### PR TITLE
Set toggle label color to black in light theme

### DIFF
--- a/main.css
+++ b/main.css
@@ -22,7 +22,7 @@
   --chip-bg: rgba(255, 179, 71, 0.2);
   --chip-text: #ff7f50;
   --toggle-bg: rgba(255, 255, 255, 0.85);
-  --toggle-fg: var(--text-main);
+  --toggle-fg: #000000;
   --toggle-shadow: rgba(31, 27, 44, 0.18);
 }
 


### PR DESCRIPTION
## Summary
- change the light-theme toggle foreground color variable to render button text in solid black

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d8a98660d0832bb58b837bea19371e