### PR TITLE
Ensure dark theme toggles use black typography

### DIFF
--- a/main.css
+++ b/main.css
@@ -42,8 +42,8 @@
   --border-subtle: rgba(126, 243, 179, 0.24);
   --chip-bg: rgba(126, 243, 179, 0.15);
   --chip-text: #7ef3b3;
-  --toggle-bg: rgba(12, 13, 18, 0.9);
-  --toggle-fg: var(--text-main);
+  --toggle-bg: rgba(255, 255, 255, 0.92);
+  --toggle-fg: #000000;
   --toggle-shadow: rgba(5, 6, 10, 0.55);
 }
 
@@ -186,6 +186,7 @@ body {
 }
 
 [data-theme="dark"] .toggle-button[aria-pressed="true"] {
+  color: #000000;
   box-shadow: 0 12px 26px rgba(126, 243, 179, 0.24);
 }
 


### PR DESCRIPTION
## Summary
- ensure toggle buttons switch to light backgrounds and black text when dark mode is active
- override pressed toggle color in dark theme to maintain contrast and readability

## Testing
- `python -m http.server 8000` (manually stopped after capturing dark theme state)


------
https://chatgpt.com/codex/tasks/task_e_68d9012a5360832badd918071f6b9073