### PR TITLE
Replace menu carousel photos with responsive placeholder

### DIFF
--- a/assets/menu-placeholder.svg
+++ b/assets/menu-placeholder.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300" role="img" aria-labelledby="title desc">
+  <title id="title">Marxia Café placeholder</title>
+  <desc id="desc">Abstract illustration placeholder for menu items.</desc>
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffb347" />
+      <stop offset="50%" stop-color="#ff7f50" />
+      <stop offset="100%" stop-color="#ffd8a8" />
+    </linearGradient>
+    <linearGradient id="steam" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.8)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="300" fill="#fff6e8" rx="32" />
+  <rect x="28" y="28" width="344" height="244" rx="24" fill="url(#grad)" />
+  <g fill="#ffffff" opacity="0.85">
+    <path d="M140 216c0-32 24-56 60-56s60 24 60 56v8H140z" />
+    <path d="M140 200c-8 0-14-6-14-14v-24c0-8 6-14 14-14h120c8 0 14 6 14 14v24c0 8-6 14-14 14z" />
+  </g>
+  <g fill="url(#steam)">
+    <path d="M180 88c0-12 6-22 6-34s-6-22-6-34" stroke="#ffffff" stroke-width="6" stroke-linecap="round" />
+    <path d="M200 88c0-12 6-22 6-34s-6-22-6-34" stroke="#ffffff" stroke-width="6" stroke-linecap="round" />
+    <path d="M220 88c0-12 6-22 6-34s-6-22-6-34" stroke="#ffffff" stroke-width="6" stroke-linecap="round" />
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
             <div class="product-carousel__viewport">
               <ul class="product-carousel__track">
                 <li class="product-card" data-name="Latte de Vainilla" data-price="2.90">
-                  <img src="https://images.unsplash.com/photo-1482049016688-2d3e1b311543?auto=format&fit=crop&w=400&q=80" alt="Café latte with art" loading="lazy">
+                  <img class="product-card__image" src="assets/menu-placeholder.svg" alt="Café latte with art" loading="lazy" width="400" height="300">
                   <div class="product-card__info">
                     <h3>Latte de Vainilla</h3>
                     <p class="product-card__meta">12 oz</p>
@@ -122,7 +122,7 @@
                   </div>
                 </li>
                 <li class="product-card" data-name="Croissant Artesanal" data-price="3.20">
-                  <img src="https://images.unsplash.com/photo-1504674900247-0877df9cc836?auto=format&fit=crop&w=400&q=80" alt="Fresh croissant" loading="lazy">
+                  <img class="product-card__image" src="assets/menu-placeholder.svg" alt="Fresh croissant" loading="lazy" width="400" height="300">
                   <div class="product-card__info">
                     <h3>Croissant Artesanal</h3>
                     <p class="product-card__meta">Butter &amp; marmalade</p>
@@ -137,7 +137,7 @@
                   </div>
                 </li>
                 <li class="product-card" data-name="Tortilla con Chorizo" data-price="3.70">
-                  <img src="https://images.unsplash.com/photo-1504674900247-0877df9cc836?auto=format&fit=crop&w=400&q=80" alt="Chorizo tortilla" loading="lazy">
+                  <img class="product-card__image" src="assets/menu-placeholder.svg" alt="Chorizo tortilla" loading="lazy" width="400" height="300">
                   <div class="product-card__info">
                     <h3>Tortilla con Chorizo</h3>
                     <p class="product-card__meta">4 porciones</p>
@@ -152,7 +152,7 @@
                   </div>
                 </li>
                 <li class="product-card" data-name="Parfait Tropical" data-price="3.40">
-                  <img src="https://images.unsplash.com/photo-1478145046317-39f10e56b5e9?auto=format&fit=crop&w=400&q=80" alt="Fruit parfait" loading="lazy">
+                  <img class="product-card__image" src="assets/menu-placeholder.svg" alt="Fruit parfait" loading="lazy" width="400" height="300">
                   <div class="product-card__info">
                     <h3>Parfait Tropical</h3>
                     <p class="product-card__meta">Granola &amp; yogurt</p>
@@ -167,7 +167,7 @@
                   </div>
                 </li>
                 <li class="product-card" data-name="Waffles con Miel" data-price="4.10">
-                  <img src="https://images.unsplash.com/photo-1458642849426-cfb724f15ef7?auto=format&fit=crop&w=400&q=80" alt="Waffles" loading="lazy">
+                  <img class="product-card__image" src="assets/menu-placeholder.svg" alt="Waffles" loading="lazy" width="400" height="300">
                   <div class="product-card__info">
                     <h3>Waffles con Miel</h3>
                     <p class="product-card__meta">2 piezas</p>
@@ -182,7 +182,7 @@
                   </div>
                 </li>
                 <li class="product-card" data-name="Cold Brew Naranja" data-price="3.00">
-                  <img src="https://images.unsplash.com/photo-1555396273-367ea4eb4db5?auto=format&fit=crop&w=400&q=80" alt="Cold brew coffee" loading="lazy">
+                  <img class="product-card__image" src="assets/menu-placeholder.svg" alt="Cold brew coffee" loading="lazy" width="400" height="300">
                   <div class="product-card__info">
                     <h3>Cold Brew Naranja</h3>
                     <p class="product-card__meta">16 oz</p>
@@ -197,7 +197,7 @@
                   </div>
                 </li>
                 <li class="product-card" data-name="Toast de Aguacate" data-price="3.90">
-                  <img src="https://images.unsplash.com/photo-1517686469429-8bdb88b9f907?auto=format&fit=crop&w=400&q=80" alt="Avocado toast" loading="lazy">
+                  <img class="product-card__image" src="assets/menu-placeholder.svg" alt="Avocado toast" loading="lazy" width="400" height="300">
                   <div class="product-card__info">
                     <h3>Toast de Aguacate</h3>
                     <p class="product-card__meta">Pan integral</p>
@@ -212,7 +212,7 @@
                   </div>
                 </li>
                 <li class="product-card" data-name="Torta de Cacao" data-price="3.50">
-                  <img src="https://images.unsplash.com/photo-1525755662778-989d0524087e?auto=format&fit=crop&w=400&q=80" alt="Chocolate cake" loading="lazy">
+                  <img class="product-card__image" src="assets/menu-placeholder.svg" alt="Chocolate cake" loading="lazy" width="400" height="300">
                   <div class="product-card__info">
                     <h3>Torta de Cacao</h3>
                     <p class="product-card__meta">Porción individual</p>
@@ -227,7 +227,7 @@
                   </div>
                 </li>
                 <li class="product-card" data-name="Sanduche Sunrise" data-price="3.60">
-                  <img src="https://images.unsplash.com/photo-1481391046821-352b495b3201?auto=format&fit=crop&w=400&q=80" alt="Breakfast sandwich" loading="lazy">
+                  <img class="product-card__image" src="assets/menu-placeholder.svg" alt="Breakfast sandwich" loading="lazy" width="400" height="300">
                   <div class="product-card__info">
                     <h3>Sanduche Sunrise</h3>
                     <p class="product-card__meta">Huevos y jamón</p>
@@ -242,7 +242,7 @@
                   </div>
                 </li>
                 <li class="product-card" data-name="Matcha Helado" data-price="3.10">
-                  <img src="https://images.unsplash.com/photo-1505253758473-96b7015fcd40?auto=format&fit=crop&w=400&q=80" alt="Iced matcha" loading="lazy">
+                  <img class="product-card__image" src="assets/menu-placeholder.svg" alt="Iced matcha" loading="lazy" width="400" height="300">
                   <div class="product-card__info">
                     <h3>Matcha Helado</h3>
                     <p class="product-card__meta">Sin azúcar</p>

--- a/main.css
+++ b/main.css
@@ -434,11 +434,14 @@ body {
   transition: transform var(--transition), box-shadow var(--transition);
 }
 
-.product-card img {
+.product-card__image {
   width: 100%;
+  aspect-ratio: 4 / 3;
   height: auto;
   display: block;
   border-radius: 18px;
+  object-fit: cover;
+  background: linear-gradient(135deg, rgba(255, 179, 71, 0.35), rgba(255, 127, 80, 0.25));
 }
 
 .product-card:hover,


### PR DESCRIPTION
## Summary
- replace external Unsplash menu photos with a locally hosted placeholder illustration to avoid blocked assets
- update carousel image styling to enforce a consistent aspect ratio and improve mobile visibility

## Testing
- python3 -m http.server 8000 (manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68d90cd40ffc832ba21727a3a08b57ae