### PR TITLE
Update pay drawer background and FAB dismissal

### DIFF
--- a/main.css
+++ b/main.css
@@ -935,6 +935,29 @@ body {
   right: 0;
   top: 50%;
   transform: translateY(-50%);
+  color: #1f2937;
+}
+
+#payDrawer .drawer__content {
+  background: #f3f4f6;
+  color: #1f2937;
+}
+
+#payDrawer .drawer__body {
+  color: #4b5563;
+}
+
+#payDrawer .payment-list li {
+  background: #ffffff;
+  color: #1f2937;
+}
+
+#payDrawer .payment-list__total {
+  color: #1f2937;
+}
+
+#payDrawer .payment-list__empty {
+  color: #4b5563;
 }
 
 .drawer__close {

--- a/main.js
+++ b/main.js
@@ -638,6 +638,32 @@
     drawer.setAttribute('aria-hidden', 'true');
   };
 
+  const closeAllDrawers = () => {
+    drawers.forEach((drawer) => {
+      closeDrawer(drawer);
+    });
+  };
+
+  const resetFabStates = () => {
+    fabButtons.forEach((button) => {
+      if (!(button instanceof HTMLElement)) {
+        return;
+      }
+      if (button.hasAttribute('aria-pressed')) {
+        button.setAttribute('aria-pressed', 'false');
+      }
+      if (button.hasAttribute('aria-expanded')) {
+        button.setAttribute('aria-expanded', 'false');
+      }
+    });
+  };
+
+  const exitAllFabInteractions = () => {
+    closeMenus();
+    closeAllDrawers();
+    resetFabStates();
+  };
+
   const toggleFabDrawer = (fab, drawerId) => {
     if (!(fab instanceof HTMLElement)) {
       return;
@@ -683,14 +709,8 @@
     }
 
     if (target.matches('[data-close-drawer]')) {
-      const drawer = target.closest('.drawer');
-      closeDrawer(drawer);
-      if (drawer?.id === 'chatDrawer') {
-        fabChat?.setAttribute('aria-pressed', 'false');
-      }
-      if (drawer?.id === 'payDrawer') {
-        fabPay?.setAttribute('aria-pressed', 'false');
-      }
+      exitAllFabInteractions();
+      return;
     }
 
     if (target === fabLanguage) {
@@ -719,11 +739,21 @@
     setupDraggableDrawer(drawer);
     drawer.addEventListener('click', (event) => {
       if (event.target === drawer) {
-        closeDrawer(drawer);
-        fabChat?.setAttribute('aria-pressed', 'false');
-        fabPay?.setAttribute('aria-pressed', 'false');
+        exitAllFabInteractions();
       }
     });
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key !== 'Escape') {
+      return;
+    }
+    const anyDrawerOpen = drawers.some((drawer) => drawer.getAttribute('aria-hidden') === 'false');
+    const anyMenuOpen = fabMenus.some((menu) => menu.dataset.open === 'true');
+    if (anyDrawerOpen || anyMenuOpen) {
+      event.preventDefault();
+      exitAllFabInteractions();
+    }
   });
 
   if (typeof largeScreenQuery.addEventListener === 'function') {


### PR DESCRIPTION
## Summary
- restyle the payment summary drawer with a light gray palette for improved contrast
- centralize FAB dismissal so close buttons, overlays, and Escape reset drawers and menus

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d90e6dca40832bbdb17f8b73a5739f