### PR TITLE
Ensure mobile carousel shows single card

### DIFF
--- a/main.css
+++ b/main.css
@@ -1172,19 +1172,25 @@ body {
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width: 768px) {
   .product-carousel {
     grid-template-columns: 1fr;
     gap: 0.75rem;
   }
 
   .product-carousel__viewport {
-    overflow: visible;
+    overflow: hidden;
     padding-inline: 3.5rem;
   }
 
+  .product-carousel__track {
+    gap: 1rem;
+  }
+
   .product-card {
-    min-width: clamp(200px, 100%, 320px);
+    flex: 0 0 100%;
+    max-width: 100%;
+    min-width: auto;
   }
 
   .carousel__control {

--- a/main.js
+++ b/main.js
@@ -353,14 +353,17 @@
       return;
     }
     const styles = window.getComputedStyle(carouselTrack);
-    const gapValue = parseFloat(styles.columnGap || styles.gap || '0');
+    const gapValue = Number.parseFloat(styles.columnGap || styles.gap || '0') || 0;
     const cardWidth = productCards[0].getBoundingClientRect().width;
     const viewportWidth = carouselViewport.getBoundingClientRect().width;
     const totalSlideWidth = cardWidth + gapValue;
     if (!Number.isFinite(totalSlideWidth) || totalSlideWidth <= 0) {
       return;
     }
-    const visibleSlides = Math.max(1, Math.floor((viewportWidth + gapValue) / totalSlideWidth));
+    const prefersSingleSlide = window.matchMedia('(max-width: 768px)').matches;
+    const visibleSlides = prefersSingleSlide
+      ? 1
+      : Math.max(1, Math.floor((viewportWidth + gapValue) / totalSlideWidth));
     maxSlideIndex = Math.max(0, productCards.length - visibleSlides);
     currentSlideIndex = Math.min(currentSlideIndex, maxSlideIndex);
     const offset = currentSlideIndex * totalSlideWidth;


### PR DESCRIPTION
## Summary
- update mobile carousel styles so the menu viewport only shows one card at a time on small screens
- adjust carousel logic to force a single visible slide on viewports narrower than tablets and improve gap parsing

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d9135f5358832bb0fea2fd7b03f1f5