### PR TITLE
Remove operational checklist content from site

### DIFF
--- a/index.html
+++ b/index.html
@@ -369,27 +369,6 @@
       </article>
     </section>
 
-    <section class="operations" aria-labelledby="operations-title">
-      <header class="section-header">
-        <h2 id="operations-title" data-i18n="operationsTitle">Operational readiness checklist</h2>
-        <p data-i18n="operationsSubtitle">Confirm the essentials beyond cybersecurity before launch.</p>
-      </header>
-      <ul class="operations__list">
-        <li data-i18n="operationsMenu">
-          Standardize menu documentation, allergen labeling, and daily prep guides.
-        </li>
-        <li data-i18n="operationsSuppliers">
-          Align supplier contracts, delivery windows, and verified backup vendors.
-        </li>
-        <li data-i18n="operationsService">
-          Train staff on service scripts, accessibility etiquette, and escalation paths.
-        </li>
-        <li data-i18n="operationsMarketing">
-          Schedule neighborhood marketing, loyalty pushes, and community partnerships.
-        </li>
-      </ul>
-    </section>
-
   </main>
 
   <aside class="fab-group" aria-label="Floating actions">

--- a/main.css
+++ b/main.css
@@ -523,60 +523,6 @@ body {
   gap: 1.75rem;
 }
 
-.operations {
-  width: min(1200px, 100%);
-  margin: 0 auto 5rem;
-  padding: 2.5rem 1.75rem 3rem;
-  border-radius: var(--radius-lg);
-  background: var(--surface);
-  box-shadow: var(--shadow-soft);
-  display: grid;
-  gap: 1.75rem;
-  transition: background var(--transition), box-shadow var(--transition);
-}
-
-.operations__list {
-  display: grid;
-  gap: 1.25rem;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.operations__list li {
-  position: relative;
-  padding-left: 2.5rem;
-  font-size: 1rem;
-  line-height: 1.7;
-  color: var(--text-muted);
-}
-
-.operations__list li::before {
-  content: "✓";
-  position: absolute;
-  left: 0;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 1.5rem;
-  height: 1.5rem;
-  border-radius: 50%;
-  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
-  box-shadow: 0 10px 18px rgba(255, 127, 80, 0.18);
-  display: grid;
-  place-items: center;
-  font-size: 0.9rem;
-  font-weight: 700;
-  color: #ffffff;
-}
-
-[data-theme="dark"] .operations {
-  box-shadow: var(--shadow-soft);
-}
-
-[data-theme="dark"] .operations__list li::before {
-  box-shadow: 0 10px 20px rgba(126, 243, 179, 0.2);
-}
-
 .insights__grid {
   display: grid;
   gap: 1.5rem;

--- a/main.js
+++ b/main.js
@@ -94,12 +94,6 @@
       fabThemeLabel: 'Theme options',
       fabChatLabel: 'Live chat',
       fabPayLabel: 'Payment summary',
-      operationsTitle: 'Operational readiness checklist',
-      operationsSubtitle: 'Confirm the essentials beyond cybersecurity before launch.',
-      operationsMenu: 'Standardize menu documentation, allergen labeling, and daily prep guides.',
-      operationsSuppliers: 'Align supplier contracts, delivery windows, and verified backup vendors.',
-      operationsService: 'Train staff on service scripts, accessibility etiquette, and escalation paths.',
-      operationsMarketing: 'Schedule neighborhood marketing, loyalty pushes, and community partnerships.',
     },
     es: {
       headline: 'Marxia Café y Bocaditos',
@@ -150,12 +144,6 @@
       fabThemeLabel: 'Opciones de tema',
       fabChatLabel: 'Chat en vivo',
       fabPayLabel: 'Resumen de pago',
-      operationsTitle: 'Lista de verificación operativa',
-      operationsSubtitle: 'Confirma lo esencial más allá de la ciberseguridad antes del lanzamiento.',
-      operationsMenu: 'Estandariza la documentación del menú, el etiquetado de alérgenos y las guías de preparación diaria.',
-      operationsSuppliers: 'Alinea contratos con proveedores, ventanas de entrega y proveedores de respaldo verificados.',
-      operationsService: 'Capacita al equipo en guiones de servicio, etiqueta de accesibilidad y rutas de escalamiento.',
-      operationsMarketing: 'Programa marketing barrial, campañas de fidelización y alianzas comunitarias.',
     },
   };
 


### PR DESCRIPTION
## Summary
- remove the operational readiness checklist section from the landing page
- delete the associated translations and styles for the checklist content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d914107cd4832b93b54dea3ca37df2