### PR TITLE
Add branded beverage illustrations to menu carousel

### DIFF
--- a/assets/coffee-cup.svg
+++ b/assets/coffee-cup.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300" role="img" aria-labelledby="title desc">
+  <title id="title">Coffee cup illustration</title>
+  <desc id="desc">Stylized Marxia Café cup with steam iconography.</desc>
+  <defs>
+    <linearGradient id="coffeeGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4b2e2b" />
+      <stop offset="60%" stop-color="#7a4d2a" />
+      <stop offset="100%" stop-color="#cba16a" />
+    </linearGradient>
+    <linearGradient id="steamGradient" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.9)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="300" fill="#fbf1e6" rx="36" />
+  <rect x="28" y="32" width="344" height="236" rx="28" fill="#f6d7b0" opacity="0.65" />
+  <g>
+    <path d="M124 214c0-44 36-74 76-74s76 30 76 74v18H124z" fill="#ffffff" opacity="0.9" />
+    <path d="M132 194c-8 0-14-6-14-14v-32c0-8 6-14 14-14h168c8 0 14 6 14 14v32c0 8-6 14-14 14z" fill="#ffffff" />
+    <path d="M160 110h112l-12 42h-88z" fill="url(#coffeeGradient)" opacity="0.95" />
+  </g>
+  <g fill="none" stroke="url(#steamGradient)" stroke-width="7" stroke-linecap="round">
+    <path d="M176 78c0-12 8-22 8-34s-8-22-8-34" />
+    <path d="M200 78c0-12 8-22 8-34s-8-22-8-34" />
+    <path d="M224 78c0-12 8-22 8-34s-8-22-8-34" />
+  </g>
+  <circle cx="200" cy="172" r="28" fill="#4b2e2b" opacity="0.65" />
+  <path d="M200 152a20 20 0 1 1-0.1 0" fill="#ffffff" opacity="0.9" />
+</svg>

--- a/assets/marxia-fried-egg-and-sausage.svg
+++ b/assets/marxia-fried-egg-and-sausage.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300" role="img" aria-labelledby="title desc">
+  <title id="title">Marxia brand fried egg and sausage illustration</title>
+  <desc id="desc">Signature Marxia styling featuring fried egg, artisan sausage, and brand banner.</desc>
+  <defs>
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffded8" />
+      <stop offset="100%" stop-color="#ffd4a3" />
+    </linearGradient>
+    <linearGradient id="bannerGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#5d2e8c" />
+      <stop offset="100%" stop-color="#9a4dc2" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="300" rx="36" fill="url(#bgGradient)" />
+  <g transform="translate(60 54)">
+    <rect x="36" y="20" width="208" height="140" rx="32" fill="#fffaf3" opacity="0.9" />
+    <rect x="48" y="34" width="184" height="112" rx="24" fill="#ffffff" />
+    <g transform="translate(72 54)">
+      <ellipse cx="52" cy="44" rx="44" ry="36" fill="#ffffff" />
+      <circle cx="52" cy="44" r="18" fill="#ffc857" />
+      <path d="M128 10c32 0 52 20 52 40s-20 40-52 40-52-20-52-40 20-40 52-40z" fill="#d16a35" />
+      <path d="M128 26c16 0 26 10 26 24s-10 24-26 24-26-10-26-24 10-24 26-24z" fill="#f39767" />
+    </g>
+  </g>
+  <path d="M60 210h280l-44 44H104z" fill="url(#bannerGradient)" opacity="0.9" />
+  <text x="200" y="240" text-anchor="middle" font-size="32" font-family="'Montserrat', 'Arial', sans-serif" fill="#ffffff" font-weight="600">Marxia</text>
+</svg>

--- a/assets/soft-drink-7up-cola.svg
+++ b/assets/soft-drink-7up-cola.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300" role="img" aria-labelledby="title desc">
+  <title id="title">7Up cola soft drink illustration</title>
+  <desc id="desc">Refreshing green soft drink bottle placeholder inspired by 7Up branding.</desc>
+  <defs>
+    <linearGradient id="sevenUpBody" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#0d9c5b" />
+      <stop offset="60%" stop-color="#04724d" />
+      <stop offset="100%" stop-color="#024731" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="300" rx="36" fill="#edfff5" />
+  <g transform="translate(150 40)">
+    <path d="M34 0h12c4 0 6 4 6 8v24c0 6 2 10 6 14l12 12c4 4 6 8 6 14v112c0 16-10 30-30 30s-30-14-30-30V72c0-6 2-10 6-14l12-12c4-4 6-8 6-14V8c0-4 2-8 6-8z" fill="url(#sevenUpBody)" />
+    <rect x="16" y="54" width="60" height="32" rx="12" fill="#ffffff" opacity="0.9" />
+    <text x="46" y="76" text-anchor="middle" font-size="16" font-family="'Montserrat', 'Arial', sans-serif" font-weight="600" fill="#0d9c5b">7Up</text>
+  </g>
+  <circle cx="200" cy="214" r="18" fill="#f44336" opacity="0.85" />
+</svg>

--- a/assets/soft-drink-coca-cola.svg
+++ b/assets/soft-drink-coca-cola.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300" role="img" aria-labelledby="title desc">
+  <title id="title">Coca Cola soft drink illustration</title>
+  <desc id="desc">Stylized Marxia Cola bottle inspired by Coca Cola red branding.</desc>
+  <defs>
+    <linearGradient id="cokeBody" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#c8102e" />
+      <stop offset="60%" stop-color="#a00c24" />
+      <stop offset="100%" stop-color="#4a0a15" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="300" rx="36" fill="#fff2f2" />
+  <g transform="translate(150 40)">
+    <path d="M34 0h12c4 0 6 4 6 8v24c0 6 2 10 6 14l12 12c4 4 6 8 6 14v112c0 16-10 30-30 30s-30-14-30-30V72c0-6 2-10 6-14l12-12c4-4 6-8 6-14V8c0-4 2-8 6-8z" fill="url(#cokeBody)" />
+    <rect x="16" y="52" width="60" height="32" rx="12" fill="#ffffff" opacity="0.9" />
+    <text x="46" y="74" text-anchor="middle" font-size="16" font-family="'Montserrat', 'Arial', sans-serif" font-weight="600" fill="#c8102e">Cola</text>
+  </g>
+</svg>

--- a/assets/soft-drink-fanta-cola.svg
+++ b/assets/soft-drink-fanta-cola.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300" role="img" aria-labelledby="title desc">
+  <title id="title">Fanta cola soft drink illustration</title>
+  <desc id="desc">Vibrant orange soft drink bottle placeholder inspired by Fanta branding.</desc>
+  <defs>
+    <linearGradient id="fantaBody" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ff9f1c" />
+      <stop offset="60%" stop-color="#ff7f11" />
+      <stop offset="100%" stop-color="#d45d00" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="300" rx="36" fill="#fff7ed" />
+  <g transform="translate(150 40)">
+    <path d="M34 0h12c4 0 6 4 6 8v24c0 6 2 10 6 14l12 12c4 4 6 8 6 14v112c0 16-10 30-30 30s-30-14-30-30V72c0-6 2-10 6-14l12-12c4-4 6-8 6-14V8c0-4 2-8 6-8z" fill="url(#fantaBody)" />
+    <rect x="14" y="56" width="64" height="30" rx="12" fill="#ffffff" opacity="0.9" />
+    <text x="46" y="76" text-anchor="middle" font-size="16" font-family="'Montserrat', 'Arial', sans-serif" font-weight="600" fill="#ff7f11">Fanta</text>
+  </g>
+</svg>

--- a/assets/soft-drink-gallito-cola.svg
+++ b/assets/soft-drink-gallito-cola.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300" role="img" aria-labelledby="title desc">
+  <title id="title">Gallito cola soft drink illustration</title>
+  <desc id="desc">Bold purple and gold beverage placeholder referencing Gallito cola branding.</desc>
+  <defs>
+    <linearGradient id="gallitoBody" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#512da8" />
+      <stop offset="60%" stop-color="#311b92" />
+      <stop offset="100%" stop-color="#140d3f" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="300" rx="36" fill="#f5f0ff" />
+  <g transform="translate(150 40)">
+    <path d="M34 0h12c4 0 6 4 6 8v24c0 6 2 10 6 14l12 12c4 4 6 8 6 14v112c0 16-10 30-30 30s-30-14-30-30V72c0-6 2-10 6-14l12-12c4-4 6-8 6-14V8c0-4 2-8 6-8z" fill="url(#gallitoBody)" />
+    <rect x="18" y="54" width="58" height="32" rx="12" fill="#ffeb3b" opacity="0.92" />
+    <text x="46" y="76" text-anchor="middle" font-size="16" font-family="'Montserrat', 'Arial', sans-serif" font-weight="600" fill="#512da8">Gallito</text>
+  </g>
+</svg>

--- a/assets/soft-drink-inca-cola.svg
+++ b/assets/soft-drink-inca-cola.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300" role="img" aria-labelledby="title desc">
+  <title id="title">Inca cola soft drink illustration</title>
+  <desc id="desc">Golden soda bottle placeholder inspired by Inca Kola brand colors.</desc>
+  <defs>
+    <linearGradient id="incaBody" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ffe066" />
+      <stop offset="60%" stop-color="#ffc300" />
+      <stop offset="100%" stop-color="#ff922b" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="300" rx="36" fill="#fffbe6" />
+  <g transform="translate(150 40)">
+    <path d="M34 0h12c4 0 6 4 6 8v24c0 6 2 10 6 14l12 12c4 4 6 8 6 14v112c0 16-10 30-30 30s-30-14-30-30V72c0-6 2-10 6-14l12-12c4-4 6-8 6-14V8c0-4 2-8 6-8z" fill="url(#incaBody)" />
+    <rect x="16" y="54" width="60" height="32" rx="12" fill="#1b4dcc" opacity="0.9" />
+    <text x="46" y="76" text-anchor="middle" font-size="16" font-family="'Montserrat', 'Arial', sans-serif" font-weight="600" fill="#ffe066">Inca</text>
+  </g>
+</svg>

--- a/assets/soft-drink-manzana-cola.svg
+++ b/assets/soft-drink-manzana-cola.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300" role="img" aria-labelledby="title desc">
+  <title id="title">Manzana cola soft drink illustration</title>
+  <desc id="desc">Apple-flavored soda placeholder inspired by Manzana cola branding.</desc>
+  <defs>
+    <linearGradient id="manzanaBody" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#96d35f" />
+      <stop offset="60%" stop-color="#67b53f" />
+      <stop offset="100%" stop-color="#2f7d1f" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="300" rx="36" fill="#f2fff2" />
+  <g transform="translate(150 40)">
+    <path d="M34 0h12c4 0 6 4 6 8v24c0 6 2 10 6 14l12 12c4 4 6 8 6 14v112c0 16-10 30-30 30s-30-14-30-30V72c0-6 2-10 6-14l12-12c4-4 6-8 6-14V8c0-4 2-8 6-8z" fill="url(#manzanaBody)" />
+    <rect x="16" y="54" width="60" height="32" rx="12" fill="#ffffff" opacity="0.9" />
+    <text x="46" y="76" text-anchor="middle" font-size="16" font-family="'Montserrat', 'Arial', sans-serif" font-weight="600" fill="#2f7d1f">Manzana</text>
+  </g>
+  <path d="M196 210c0-14 12-24 24-24 14 0 24 12 24 24s-10 24-24 24c-12 0-24-10-24-24z" fill="#f0544f" opacity="0.8" />
+</svg>

--- a/assets/soft-drink-pepsi-cola.svg
+++ b/assets/soft-drink-pepsi-cola.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300" role="img" aria-labelledby="title desc">
+  <title id="title">Pepsi cola soft drink illustration</title>
+  <desc id="desc">Soft drink bottle placeholder featuring Pepsi brand colors.</desc>
+  <defs>
+    <linearGradient id="pepsiBody" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#004b93" />
+      <stop offset="60%" stop-color="#002f6c" />
+      <stop offset="100%" stop-color="#011a3c" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="300" rx="36" fill="#f0f6ff" />
+  <g transform="translate(150 40)">
+    <path d="M34 0h12c4 0 6 4 6 8v24c0 6 2 10 6 14l12 12c4 4 6 8 6 14v112c0 16-10 30-30 30s-30-14-30-30V72c0-6 2-10 6-14l12-12c4-4 6-8 6-14V8c0-4 2-8 6-8z" fill="url(#pepsiBody)" />
+    <rect x="16" y="56" width="60" height="32" rx="12" fill="#ffffff" opacity="0.9" />
+    <g transform="translate(24 60)">
+      <path d="M22 0c12 0 22 10 22 22S34 44 22 44 0 34 0 22 10 0 22 0z" fill="#e4002b" />
+      <path d="M1.6 20c4-8 12-12 20.4-12C38 8 44 18 44 18s-10 12-24 12c-8 0-14-2-18.4-6z" fill="#ffffff" />
+    </g>
+  </g>
+</svg>

--- a/assets/tortilla-sausage-fried-eggs.svg
+++ b/assets/tortilla-sausage-fried-eggs.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300" role="img" aria-labelledby="title desc">
+  <title id="title">Tortilla, sausage and fried eggs illustration</title>
+  <desc id="desc">Playful plate featuring tortilla slices, sausage and sunny-side-up eggs representing Marxia breakfast.</desc>
+  <defs>
+    <radialGradient id="plateGradient" cx="50%" cy="50%" r="70%">
+      <stop offset="0%" stop-color="#ffffff" />
+      <stop offset="100%" stop-color="#e2e6f4" />
+    </radialGradient>
+    <linearGradient id="eggGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#fff3c4" />
+      <stop offset="100%" stop-color="#ffe27a" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="300" fill="#fff9f0" rx="36" />
+  <g transform="translate(60 40)">
+    <ellipse cx="140" cy="110" rx="136" ry="96" fill="url(#plateGradient)" />
+    <g opacity="0.95">
+      <ellipse cx="124" cy="104" rx="46" ry="36" fill="#d15829" />
+      <ellipse cx="124" cy="104" rx="32" ry="24" fill="#f5a46b" />
+      <ellipse cx="88" cy="72" rx="48" ry="36" fill="#f2c995" />
+      <ellipse cx="188" cy="140" rx="48" ry="36" fill="#f2c995" />
+    </g>
+    <g>
+      <ellipse cx="80" cy="140" rx="44" ry="32" fill="#ffffff" />
+      <circle cx="80" cy="140" r="18" fill="url(#eggGradient)" />
+      <ellipse cx="208" cy="80" rx="44" ry="32" fill="#ffffff" />
+      <circle cx="208" cy="80" r="18" fill="url(#eggGradient)" />
+      <path d="M156 40a20 20 0 1 1 0 40 20 20 0 1 1 0-40" fill="#c24f2d" opacity="0.9" />
+      <path d="M156 52a8 8 0 1 1 0 16 8 8 0 1 1 0-16" fill="#872d1a" opacity="0.65" />
+    </g>
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
             <div class="product-carousel__viewport">
               <ul class="product-carousel__track">
                 <li class="product-card" data-name="Latte de Vainilla" data-price="2.90">
-                  <img class="product-card__image" src="assets/menu-placeholder.svg" alt="Café latte with art" loading="lazy" width="400" height="300">
+                  <img class="product-card__image" src="assets/coffee-cup.svg" alt="Café latte with art" loading="lazy" width="400" height="300">
                   <div class="product-card__info">
                     <h3>Latte de Vainilla</h3>
                     <p class="product-card__meta">12 oz</p>
@@ -137,7 +137,7 @@
                   </div>
                 </li>
                 <li class="product-card" data-name="Tortilla con Chorizo" data-price="3.70">
-                  <img class="product-card__image" src="assets/menu-placeholder.svg" alt="Chorizo tortilla" loading="lazy" width="400" height="300">
+                  <img class="product-card__image" src="assets/tortilla-sausage-fried-eggs.svg" alt="Chorizo tortilla" loading="lazy" width="400" height="300">
                   <div class="product-card__info">
                     <h3>Tortilla con Chorizo</h3>
                     <p class="product-card__meta">4 porciones</p>
@@ -227,7 +227,7 @@
                   </div>
                 </li>
                 <li class="product-card" data-name="Sanduche Sunrise" data-price="3.60">
-                  <img class="product-card__image" src="assets/menu-placeholder.svg" alt="Breakfast sandwich" loading="lazy" width="400" height="300">
+                  <img class="product-card__image" src="assets/marxia-fried-egg-and-sausage.svg" alt="Breakfast sandwich" loading="lazy" width="400" height="300">
                   <div class="product-card__info">
                     <h3>Sanduche Sunrise</h3>
                     <p class="product-card__meta">Huevos y jamón</p>
@@ -249,6 +249,111 @@
                   </div>
                   <div class="product-card__footer">
                     <span class="product-card__price" aria-label="Price">$3.10</span>
+                    <div class="product-card__controls">
+                      <button type="button" class="product-card__button" data-cart="add" data-i18n="addToOrder">+ Add</button>
+                      <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder">- Remove</button>
+                    </div>
+                    <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
+                  </div>
+                </li>
+                <li class="product-card" data-name="Coca Cola" data-price="1.50">
+                  <img class="product-card__image" src="assets/soft-drink-coca-cola.svg" alt="Botella de Coca Cola" loading="lazy" width="400" height="300">
+                  <div class="product-card__info">
+                    <h3>Coca Cola</h3>
+                    <p class="product-card__meta">Botella 355 ml</p>
+                  </div>
+                  <div class="product-card__footer">
+                    <span class="product-card__price" aria-label="Price">$1.50</span>
+                    <div class="product-card__controls">
+                      <button type="button" class="product-card__button" data-cart="add" data-i18n="addToOrder">+ Add</button>
+                      <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder">- Remove</button>
+                    </div>
+                    <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
+                  </div>
+                </li>
+                <li class="product-card" data-name="Fanta Cola" data-price="1.45">
+                  <img class="product-card__image" src="assets/soft-drink-fanta-cola.svg" alt="Botella de Fanta" loading="lazy" width="400" height="300">
+                  <div class="product-card__info">
+                    <h3>Fanta Cola</h3>
+                    <p class="product-card__meta">Botella 355 ml</p>
+                  </div>
+                  <div class="product-card__footer">
+                    <span class="product-card__price" aria-label="Price">$1.45</span>
+                    <div class="product-card__controls">
+                      <button type="button" class="product-card__button" data-cart="add" data-i18n="addToOrder">+ Add</button>
+                      <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder">- Remove</button>
+                    </div>
+                    <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
+                  </div>
+                </li>
+                <li class="product-card" data-name="Gallito Cola" data-price="1.45">
+                  <img class="product-card__image" src="assets/soft-drink-gallito-cola.svg" alt="Botella de Gallito Cola" loading="lazy" width="400" height="300">
+                  <div class="product-card__info">
+                    <h3>Gallito Cola</h3>
+                    <p class="product-card__meta">Botella 355 ml</p>
+                  </div>
+                  <div class="product-card__footer">
+                    <span class="product-card__price" aria-label="Price">$1.45</span>
+                    <div class="product-card__controls">
+                      <button type="button" class="product-card__button" data-cart="add" data-i18n="addToOrder">+ Add</button>
+                      <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder">- Remove</button>
+                    </div>
+                    <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
+                  </div>
+                </li>
+                <li class="product-card" data-name="Inca Cola" data-price="1.55">
+                  <img class="product-card__image" src="assets/soft-drink-inca-cola.svg" alt="Botella de Inca Cola" loading="lazy" width="400" height="300">
+                  <div class="product-card__info">
+                    <h3>Inca Cola</h3>
+                    <p class="product-card__meta">Botella 355 ml</p>
+                  </div>
+                  <div class="product-card__footer">
+                    <span class="product-card__price" aria-label="Price">$1.55</span>
+                    <div class="product-card__controls">
+                      <button type="button" class="product-card__button" data-cart="add" data-i18n="addToOrder">+ Add</button>
+                      <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder">- Remove</button>
+                    </div>
+                    <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
+                  </div>
+                </li>
+                <li class="product-card" data-name="Manzana Cola" data-price="1.45">
+                  <img class="product-card__image" src="assets/soft-drink-manzana-cola.svg" alt="Botella de Manzana Cola" loading="lazy" width="400" height="300">
+                  <div class="product-card__info">
+                    <h3>Manzana Cola</h3>
+                    <p class="product-card__meta">Botella 355 ml</p>
+                  </div>
+                  <div class="product-card__footer">
+                    <span class="product-card__price" aria-label="Price">$1.45</span>
+                    <div class="product-card__controls">
+                      <button type="button" class="product-card__button" data-cart="add" data-i18n="addToOrder">+ Add</button>
+                      <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder">- Remove</button>
+                    </div>
+                    <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
+                  </div>
+                </li>
+                <li class="product-card" data-name="Pepsi Cola" data-price="1.50">
+                  <img class="product-card__image" src="assets/soft-drink-pepsi-cola.svg" alt="Botella de Pepsi Cola" loading="lazy" width="400" height="300">
+                  <div class="product-card__info">
+                    <h3>Pepsi Cola</h3>
+                    <p class="product-card__meta">Botella 355 ml</p>
+                  </div>
+                  <div class="product-card__footer">
+                    <span class="product-card__price" aria-label="Price">$1.50</span>
+                    <div class="product-card__controls">
+                      <button type="button" class="product-card__button" data-cart="add" data-i18n="addToOrder">+ Add</button>
+                      <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder">- Remove</button>
+                    </div>
+                    <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
+                  </div>
+                </li>
+                <li class="product-card" data-name="7Up Cola" data-price="1.45">
+                  <img class="product-card__image" src="assets/soft-drink-7up-cola.svg" alt="Botella de 7Up" loading="lazy" width="400" height="300">
+                  <div class="product-card__info">
+                    <h3>7Up Cola</h3>
+                    <p class="product-card__meta">Botella 355 ml</p>
+                  </div>
+                  <div class="product-card__footer">
+                    <span class="product-card__price" aria-label="Price">$1.45</span>
                     <div class="product-card__controls">
                       <button type="button" class="product-card__button" data-cart="add" data-i18n="addToOrder">+ Add</button>
                       <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder">- Remove</button>


### PR DESCRIPTION
## Summary
- add dedicated SVG placeholders for coffee and Marxia breakfast items
- extend the carousel with soft drink cards and brand-specific artwork

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d9899b9084832b8b8c8fe469e54af6