### PR TITLE
Update menu names to use spaced formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,18 +106,18 @@
             </button>
             <div class="product-carousel__viewport">
               <ul class="product-carousel__track">
-                <li class="product-card" data-name="Café de la casa" data-price="2.25">
+                <li class="product-card" data-name="Cup of Coffee" data-price="2.25">
                   <img
                     class="product-card__image"
                     src="https://twilight-glade-ca07.distraction.workers.dev/img/cup-of-coffee"
-                    alt="Cup of coffee"
+                    alt="Cup of Coffee"
                     loading="lazy"
                     width="400"
                     height="300"
                     referrerpolicy="no-referrer"
                   >
                   <div class="product-card__info">
-                    <h3>Café de la casa</h3>
+                    <h3>Cup of Coffee</h3>
                     <p class="product-card__meta">Tueste medio · 12 oz</p>
                   </div>
                   <div class="product-card__footer">
@@ -129,18 +129,18 @@
                     <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
                   </div>
                 </li>
-                <li class="product-card" data-name="Combo Marxia" data-price="5.90">
+                <li class="product-card" data-name="Coffee Cup Tortilla Sausage Fried Eggs Marxia" data-price="5.90">
                   <img
                     class="product-card__image"
                     src="https://twilight-glade-ca07.distraction.workers.dev/img/coffeecup_tortilla_sausage_friedEggs_Marxia"
-                    alt="Coffee + tortilla + sausage + fried eggs"
+                    alt="Coffee Cup Tortilla Sausage Fried Eggs Marxia"
                     loading="lazy"
                     width="400"
                     height="300"
                     referrerpolicy="no-referrer"
                   >
                   <div class="product-card__info">
-                    <h3>Combo Marxia</h3>
+                    <h3>Coffee Cup Tortilla Sausage Fried Eggs Marxia</h3>
                     <p class="product-card__meta">Café + tortilla + huevos + salchicha</p>
                   </div>
                   <div class="product-card__footer">
@@ -152,7 +152,7 @@
                     <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
                   </div>
                 </li>
-                <li class="product-card" data-name="Tortilla artesanal" data-price="3.10">
+                <li class="product-card" data-name="Tortilla" data-price="3.10">
                   <img
                     class="product-card__image"
                     src="https://twilight-glade-ca07.distraction.workers.dev/img/tortilla"
@@ -163,7 +163,7 @@
                     referrerpolicy="no-referrer"
                   >
                   <div class="product-card__info">
-                    <h3>Tortilla artesanal</h3>
+                    <h3>Tortilla</h3>
                     <p class="product-card__meta">4 porciones</p>
                   </div>
                   <div class="product-card__footer">
@@ -175,18 +175,18 @@
                     <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
                   </div>
                 </li>
-                <li class="product-card" data-name="Huevos campesinos" data-price="4.20">
+                <li class="product-card" data-name="Fried Eggs Sausage" data-price="4.20">
                   <img
                     class="product-card__image"
                     src="https://twilight-glade-ca07.distraction.workers.dev/img/friedEggs-sausage"
-                    alt="Fried eggs + sausage"
+                    alt="Fried Eggs Sausage"
                     loading="lazy"
                     width="400"
                     height="300"
                     referrerpolicy="no-referrer"
                   >
                   <div class="product-card__info">
-                    <h3>Huevos campesinos</h3>
+                    <h3>Fried Eggs Sausage</h3>
                     <p class="product-card__meta">Huevos fritos + salchicha</p>
                   </div>
                   <div class="product-card__footer">
@@ -202,7 +202,7 @@
                   <img
                     class="product-card__image"
                     src="https://twilight-glade-ca07.distraction.workers.dev/img/Coca-Cola"
-                    alt="Coca-Cola"
+                    alt="Coca Cola"
                     loading="lazy"
                     width="400"
                     height="300"
@@ -225,7 +225,7 @@
                   <img
                     class="product-card__image"
                     src="https://twilight-glade-ca07.distraction.workers.dev/img/pepsi-cola"
-                    alt="Pepsi"
+                    alt="Pepsi Cola"
                     loading="lazy"
                     width="400"
                     height="300"
@@ -244,18 +244,18 @@
                     <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
                   </div>
                 </li>
-                <li class="product-card" data-name="Fanta Naranja" data-price="1.45">
+                <li class="product-card" data-name="Fanta Cola" data-price="1.45">
                   <img
                     class="product-card__image"
                     src="https://twilight-glade-ca07.distraction.workers.dev/img/fanta-cola"
-                    alt="Fanta"
+                    alt="Fanta Cola"
                     loading="lazy"
                     width="400"
                     height="300"
                     referrerpolicy="no-referrer"
                   >
                   <div class="product-card__info">
-                    <h3>Fanta Naranja</h3>
+                    <h3>Fanta Cola</h3>
                     <p class="product-card__meta">Botella 355 ml</p>
                   </div>
                   <div class="product-card__footer">
@@ -271,7 +271,7 @@
                   <img
                     class="product-card__image"
                     src="https://twilight-glade-ca07.distraction.workers.dev/img/gallito-cola"
-                    alt="Gallito"
+                    alt="Gallito Cola"
                     loading="lazy"
                     width="400"
                     height="300"
@@ -290,18 +290,18 @@
                     <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
                   </div>
                 </li>
-                <li class="product-card" data-name="Inca Kola" data-price="1.55">
+                <li class="product-card" data-name="Inca Cola" data-price="1.55">
                   <img
                     class="product-card__image"
                     src="https://twilight-glade-ca07.distraction.workers.dev/img/inca-cola"
-                    alt="Inca Kola"
+                    alt="Inca Cola"
                     loading="lazy"
                     width="400"
                     height="300"
                     referrerpolicy="no-referrer"
                   >
                   <div class="product-card__info">
-                    <h3>Inca Kola</h3>
+                    <h3>Inca Cola</h3>
                     <p class="product-card__meta">Botella 355 ml</p>
                   </div>
                   <div class="product-card__footer">
@@ -313,18 +313,18 @@
                     <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
                   </div>
                 </li>
-                <li class="product-card" data-name="Manzana Postobón" data-price="1.45">
+                <li class="product-card" data-name="Manzana Cola" data-price="1.45">
                   <img
                     class="product-card__image"
                     src="https://twilight-glade-ca07.distraction.workers.dev/img/manzana-cola"
-                    alt="Manzana"
+                    alt="Manzana Cola"
                     loading="lazy"
                     width="400"
                     height="300"
                     referrerpolicy="no-referrer"
                   >
                   <div class="product-card__info">
-                    <h3>Manzana Postobón</h3>
+                    <h3>Manzana Cola</h3>
                     <p class="product-card__meta">Botella 355 ml</p>
                   </div>
                   <div class="product-card__footer">


### PR DESCRIPTION
## Summary
- replace hyphenated and underscored product identifiers in the Our menu cards with space-separated titles
- align the product image alt text with the new readable names for consistency

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da172d3398832b86ae2f5588f97f06