### PR TITLE
Adjust menu pricing and beverage offerings

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@
             </button>
             <div class="product-carousel__viewport">
               <ul class="product-carousel__track">
-                <li class="product-card" data-name="Cup of Coffee" data-price="2.25">
+                <li class="product-card" data-name="Cup of Coffee" data-price="0.60">
                   <img
                     class="product-card__image"
                     src="https://twilight-glade-ca07.distraction.workers.dev/img/cup-of-coffee"
@@ -121,7 +121,7 @@
                     <p class="product-card__meta">Tueste medio · 12 oz</p>
                   </div>
                   <div class="product-card__footer">
-                    <span class="product-card__price" aria-label="Price">$2.25</span>
+                    <span class="product-card__price" aria-label="Price">$0.60</span>
                     <div class="product-card__controls">
                       <button type="button" class="product-card__button" data-cart="add" data-i18n="addToOrder">+ Add</button>
                       <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder">- Remove</button>
@@ -153,7 +153,7 @@
                     <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
                   </div>
                 </li>
-                <li class="product-card" data-name="Tortilla" data-price="3.10">
+                <li class="product-card" data-name="Tortilla" data-price="1.60">
                   <img
                     class="product-card__image"
                     src="https://twilight-glade-ca07.distraction.workers.dev/img/tortilla"
@@ -168,7 +168,7 @@
                     <p class="product-card__meta">4 porciones</p>
                   </div>
                   <div class="product-card__footer">
-                    <span class="product-card__price" aria-label="Price">$3.10</span>
+                    <span class="product-card__price" aria-label="Price">$1.60</span>
                     <div class="product-card__controls">
                       <button type="button" class="product-card__button" data-cart="add" data-i18n="addToOrder">+ Add</button>
                       <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder">- Remove</button>
@@ -176,22 +176,22 @@
                     <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
                   </div>
                 </li>
-                <li class="product-card" data-name="Fried Eggs Sausage" data-price="4.20">
+                <li class="product-card" data-name="1 Fried Egg 1 Sausage" data-price="2.00">
                   <img
                     class="product-card__image"
                     src="https://twilight-glade-ca07.distraction.workers.dev/img/friedEggs-sausage"
-                    alt="Fried Eggs Sausage"
+                    alt="1 Fried Egg 1 Sausage"
                     loading="lazy"
                     width="400"
                     height="300"
                     referrerpolicy="no-referrer"
                   >
                   <div class="product-card__info">
-                    <h3>Fried Eggs Sausage</h3>
-                    <p class="product-card__meta">Huevos fritos + salchicha</p>
+                    <h3>1 Fried Egg 1 Sausage</h3>
+                    <p class="product-card__meta">1 huevo frito + 1 salchicha</p>
                   </div>
                   <div class="product-card__footer">
-                    <span class="product-card__price" aria-label="Price">$4.20</span>
+                    <span class="product-card__price" aria-label="Price">$2.00</span>
                     <div class="product-card__controls">
                       <button type="button" class="product-card__button" data-cart="add" data-i18n="addToOrder">+ Add</button>
                       <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder">- Remove</button>
@@ -199,30 +199,7 @@
                     <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
                   </div>
                 </li>
-                <li class="product-card" data-name="Coca Cola" data-price="1.50">
-                  <img
-                    class="product-card__image"
-                    src="https://twilight-glade-ca07.distraction.workers.dev/img/coca-cola"
-                    alt="Coca Cola"
-                    loading="lazy"
-                    width="400"
-                    height="300"
-                    referrerpolicy="no-referrer"
-                  >
-                  <div class="product-card__info">
-                    <h3>Coca Cola</h3>
-                    <p class="product-card__meta">Botella 355 ml</p>
-                  </div>
-                  <div class="product-card__footer">
-                    <span class="product-card__price" aria-label="Price">$1.50</span>
-                    <div class="product-card__controls">
-                      <button type="button" class="product-card__button" data-cart="add" data-i18n="addToOrder">+ Add</button>
-                      <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder">- Remove</button>
-                    </div>
-                    <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
-                  </div>
-                </li>
-                <li class="product-card" data-name="Pepsi Cola" data-price="1.50">
+                <li class="product-card" data-name="Pepsi Cola" data-price="0.60">
                   <img
                     class="product-card__image"
                     src="https://twilight-glade-ca07.distraction.workers.dev/img/pepsi-cola"
@@ -237,7 +214,7 @@
                     <p class="product-card__meta">Botella 355 ml</p>
                   </div>
                   <div class="product-card__footer">
-                    <span class="product-card__price" aria-label="Price">$1.50</span>
+                    <span class="product-card__price" aria-label="Price">$0.60</span>
                     <div class="product-card__controls">
                       <button type="button" class="product-card__button" data-cart="add" data-i18n="addToOrder">+ Add</button>
                       <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder">- Remove</button>
@@ -245,7 +222,7 @@
                     <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
                   </div>
                 </li>
-                <li class="product-card" data-name="Fanta Cola" data-price="1.45">
+                <li class="product-card" data-name="Fanta Cola" data-price="0.60">
                   <img
                     class="product-card__image"
                     src="https://twilight-glade-ca07.distraction.workers.dev/img/fanta-cola"
@@ -260,7 +237,7 @@
                     <p class="product-card__meta">Botella 355 ml</p>
                   </div>
                   <div class="product-card__footer">
-                    <span class="product-card__price" aria-label="Price">$1.45</span>
+                    <span class="product-card__price" aria-label="Price">$0.60</span>
                     <div class="product-card__controls">
                       <button type="button" class="product-card__button" data-cart="add" data-i18n="addToOrder">+ Add</button>
                       <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder">- Remove</button>
@@ -268,7 +245,7 @@
                     <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
                   </div>
                 </li>
-                <li class="product-card" data-name="Gallito Cola" data-price="1.45">
+                <li class="product-card" data-name="Gallito Cola" data-price="0.60">
                   <img
                     class="product-card__image"
                     src="https://twilight-glade-ca07.distraction.workers.dev/img/gallito-cola"
@@ -283,7 +260,7 @@
                     <p class="product-card__meta">Botella 355 ml</p>
                   </div>
                   <div class="product-card__footer">
-                    <span class="product-card__price" aria-label="Price">$1.45</span>
+                    <span class="product-card__price" aria-label="Price">$0.60</span>
                     <div class="product-card__controls">
                       <button type="button" class="product-card__button" data-cart="add" data-i18n="addToOrder">+ Add</button>
                       <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder">- Remove</button>
@@ -291,7 +268,7 @@
                     <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
                   </div>
                 </li>
-                <li class="product-card" data-name="Inca Cola" data-price="1.55">
+                <li class="product-card" data-name="Inca Cola" data-price="0.60">
                   <img
                     class="product-card__image"
                     src="https://twilight-glade-ca07.distraction.workers.dev/img/inca-cola"
@@ -306,7 +283,7 @@
                     <p class="product-card__meta">Botella 355 ml</p>
                   </div>
                   <div class="product-card__footer">
-                    <span class="product-card__price" aria-label="Price">$1.55</span>
+                    <span class="product-card__price" aria-label="Price">$0.60</span>
                     <div class="product-card__controls">
                       <button type="button" class="product-card__button" data-cart="add" data-i18n="addToOrder">+ Add</button>
                       <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder">- Remove</button>
@@ -314,7 +291,7 @@
                     <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
                   </div>
                 </li>
-                <li class="product-card" data-name="Manzana Cola" data-price="1.45">
+                <li class="product-card" data-name="Manzana Cola" data-price="0.60">
                   <img
                     class="product-card__image"
                     src="https://twilight-glade-ca07.distraction.workers.dev/img/manzana-cola"
@@ -329,7 +306,7 @@
                     <p class="product-card__meta">Botella 355 ml</p>
                   </div>
                   <div class="product-card__footer">
-                    <span class="product-card__price" aria-label="Price">$1.45</span>
+                    <span class="product-card__price" aria-label="Price">$0.60</span>
                     <div class="product-card__controls">
                       <button type="button" class="product-card__button" data-cart="add" data-i18n="addToOrder">+ Add</button>
                       <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder">- Remove</button>
@@ -337,7 +314,7 @@
                     <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
                   </div>
                 </li>
-                <li class="product-card" data-name="Seven Up" data-price="1.45">
+                <li class="product-card" data-name="Seven Up" data-price="0.60">
                   <img
                     class="product-card__image"
                     src="https://twilight-glade-ca07.distraction.workers.dev/img/seven_up"
@@ -352,7 +329,7 @@
                     <p class="product-card__meta">Botella 355 ml</p>
                   </div>
                   <div class="product-card__footer">
-                    <span class="product-card__price" aria-label="Price">$1.45</span>
+                    <span class="product-card__price" aria-label="Price">$0.60</span>
                     <div class="product-card__controls">
                       <button type="button" class="product-card__button" data-cart="add" data-i18n="addToOrder">+ Add</button>
                       <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder">- Remove</button>


### PR DESCRIPTION
## Summary
- update coffee, tortilla, and combo items to reflect new prices and naming
- remove Coca Cola from the carousel and standardize soda pricing at $0.60

## Testing
- Not run (static site change)


------
https://chatgpt.com/codex/tasks/task_e_68da4dc0a474832ba809dc406594398e