### PR TITLE
Enhance delivery checkout interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -419,12 +419,39 @@
         <div class="delivery-time" role="group" aria-labelledby="delivery-title">
           <span id="delivery-title" data-i18n="deliveryTitle">Delivery time</span>
           <div class="delivery-time__options">
-            <button type="button" class="chip" aria-pressed="true">45 min</button>
-            <button type="button" class="chip" aria-pressed="false">1 hr</button>
-            <button type="button" class="chip" aria-pressed="false">1 hr 30 min</button>
+            <button
+              type="button"
+              class="chip"
+              aria-pressed="true"
+              data-delivery-minutes="45"
+              data-label-en="45 min"
+              data-label-es="45 min"
+            >45 min</button>
+            <button
+              type="button"
+              class="chip"
+              aria-pressed="false"
+              data-delivery-minutes="60"
+              data-label-en="1 hr"
+              data-label-es="1 hr"
+            >1 hr</button>
+            <button
+              type="button"
+              class="chip"
+              aria-pressed="false"
+              data-delivery-minutes="90"
+              data-label-en="1 hr 30 min"
+              data-label-es="1 hr 30 min"
+            >1 hr 30 min</button>
           </div>
+          <p class="delivery-time__selection" data-delivery-selection aria-live="polite" data-i18n-skip-text="true"></p>
         </div>
-        <button type="button" class="button button--primary" data-i18n="checkout">Secure checkout</button>
+        <button
+          type="button"
+          class="button button--primary"
+          data-i18n="checkout"
+          data-checkout-trigger
+        >Secure checkout</button>
       </article>
     </section>
   </main>
@@ -484,6 +511,7 @@
       <div class="drawer__body">
         <ul class="payment-list" data-payment-items aria-live="polite"></ul>
         <p class="payment-list__empty" data-payment-empty data-i18n="orderSummaryEmpty">Your basket is empty. Add menu favorites to see them here.</p>
+        <p class="payment-list__eta" data-payment-delivery aria-live="polite" data-i18n-skip-text="true"></p>
         <p class="payment-list__total"><strong data-i18n="ordersTotal">Total</strong>: <span data-payment-total>$0.00</span></p>
         <button type="button" class="button button--primary" data-i18n="payNow">Pay now</button>
       </div>

--- a/main.css
+++ b/main.css
@@ -731,6 +731,12 @@ body {
   gap: 0.5rem;
 }
 
+.delivery-time__selection {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
 .chip {
   border: none;
   border-radius: 999px;
@@ -1042,6 +1048,12 @@ body {
   background: var(--surface);
   padding: 0.5rem 0.75rem;
   border-radius: 12px;
+}
+
+.payment-list__eta {
+  margin: 0 0 0.5rem;
+  font-size: 0.95rem;
+  color: var(--text-muted);
 }
 
 .payment-list__total {

--- a/main.js
+++ b/main.js
@@ -12,6 +12,7 @@
   const fabLanguageMenu = document.querySelector('#fabLanguageMenu');
   const fabThemeMenu = document.querySelector('#fabThemeMenu');
   const drawers = Array.from(document.querySelectorAll('.drawer'));
+  const payDrawer = document.querySelector('#payDrawer');
   const languageToggle = document.querySelector('#languageToggle');
   const themeToggle = document.querySelector('#themeToggle');
   const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
@@ -34,6 +35,8 @@
   const paymentList = document.querySelector('[data-payment-items]');
   const paymentEmpty = document.querySelector('[data-payment-empty]');
   const paymentTotal = document.querySelector('[data-payment-total]');
+  const deliverySelectionDisplay = document.querySelector('[data-delivery-selection]');
+  const paymentDeliveryDisplay = document.querySelector('[data-payment-delivery]');
   const smallScreenQuery = window.matchMedia('(max-width: 767px)');
   const largeScreenQuery = window.matchMedia('(min-width: 900px)');
   const draggableDrawerIds = new Set(['chatDrawer', 'payDrawer']);
@@ -43,9 +46,12 @@
   const TAX_RATE = 0.12;
   const DELIVERY_FEE = 1.5;
   const cart = new Map();
+  const checkoutTrigger = document.querySelector('[data-checkout-trigger]');
+  const DELIVERY_STORAGE_KEY = 'marxia-delivery-minutes';
   let currentSlideIndex = 0;
   let maxSlideIndex = 0;
   let currentLanguage = html.lang === 'es' ? 'es' : 'en';
+  let selectedDeliveryTime = null;
   const translations = {
     en: {
       headline: 'Marxia Café y Bocaditos',
@@ -75,6 +81,8 @@
       orderItems: 'Selected items',
       orderSummaryEmpty: 'Your basket is empty. Add menu favorites to see them here.',
       deliveryTitle: 'Delivery time',
+      deliveryEta: 'Estimated delivery: {time}',
+      deliveryEtaPrompt: 'Select a delivery time',
       checkout: 'Secure checkout',
       carouselPrev: 'Previous favorites',
       carouselNext: 'Next favorites',
@@ -125,6 +133,8 @@
       orderItems: 'Artículos seleccionados',
       orderSummaryEmpty: 'Tu pedido está vacío. Agrega favoritos del menú para verlos aquí.',
       deliveryTitle: 'Tiempo de entrega',
+      deliveryEta: 'Entrega estimada: {time}',
+      deliveryEtaPrompt: 'Selecciona el tiempo de entrega',
       checkout: 'Checkout seguro',
       carouselPrev: 'Favoritos anteriores',
       carouselNext: 'Más favoritos',
@@ -166,6 +176,105 @@
   const getTranslation = (key) => {
     const active = translations[currentLanguage] || translations.en;
     return active[key] ?? translations.en[key] ?? '';
+  };
+
+  const getDeliveryLabelForChip = (chip, lang = currentLanguage) => {
+    if (!(chip instanceof HTMLElement)) {
+      return '';
+    }
+    const dictionaryKey = lang === 'es' ? 'labelEs' : 'labelEn';
+    return chip.dataset[dictionaryKey] || chip.textContent.trim();
+  };
+
+  const updateDeliveryOptionLabels = (lang = currentLanguage) => {
+    chipButtons.forEach((chip) => {
+      const label = getDeliveryLabelForChip(chip, lang);
+      if (label) {
+        chip.textContent = label;
+      }
+    });
+  };
+
+  const syncSelectedDeliveryLabel = () => {
+    if (!selectedDeliveryTime) {
+      return;
+    }
+    const activeChip = chipButtons.find((chip) => chip.getAttribute('aria-pressed') === 'true');
+    if (activeChip) {
+      selectedDeliveryTime.label = getDeliveryLabelForChip(activeChip);
+    }
+  };
+
+  const updateDeliveryDisplay = () => {
+    const label = selectedDeliveryTime?.label;
+    const template = getTranslation('deliveryEta') || 'Estimated delivery: {time}';
+    const prompt = getTranslation('deliveryEtaPrompt') || '';
+    const message = label ? template.replace('{time}', label) : prompt;
+
+    if (deliverySelectionDisplay) {
+      deliverySelectionDisplay.textContent = message;
+      deliverySelectionDisplay.toggleAttribute('hidden', !message);
+    }
+
+    if (paymentDeliveryDisplay) {
+      paymentDeliveryDisplay.textContent = message;
+      paymentDeliveryDisplay.toggleAttribute('hidden', !message);
+    }
+  };
+
+  const setSelectedDeliveryTime = (chip, { persist = true } = {}) => {
+    if (!(chip instanceof HTMLElement)) {
+      return;
+    }
+
+    chipButtons.forEach((btn) => {
+      btn.setAttribute('aria-pressed', String(btn === chip));
+    });
+
+    const minutesValue = Number(chip.getAttribute('data-delivery-minutes') || chip.dataset.deliveryMinutes || '');
+    const minutes = Number.isFinite(minutesValue) ? minutesValue : null;
+    const label = getDeliveryLabelForChip(chip);
+
+    selectedDeliveryTime = {
+      minutes,
+      label,
+    };
+
+    if (persist && minutes !== null) {
+      try {
+        localStorage.setItem(DELIVERY_STORAGE_KEY, String(minutes));
+      } catch (error) {
+        // no-op: storage might be unavailable
+      }
+    }
+
+    updateDeliveryDisplay();
+  };
+
+  const restoreDeliverySelection = () => {
+    updateDeliveryOptionLabels();
+    let savedMinutes = null;
+    try {
+      savedMinutes = localStorage.getItem(DELIVERY_STORAGE_KEY);
+    } catch (error) {
+      savedMinutes = null;
+    }
+
+    let targetChip = null;
+    if (savedMinutes) {
+      targetChip = chipButtons.find((chip) => chip.getAttribute('data-delivery-minutes') === savedMinutes) || null;
+    }
+
+    if (!targetChip) {
+      targetChip =
+        chipButtons.find((chip) => chip.getAttribute('aria-pressed') === 'true') || chipButtons[0] || null;
+    }
+
+    if (targetChip) {
+      setSelectedDeliveryTime(targetChip, { persist: false });
+    } else {
+      updateDeliveryDisplay();
+    }
   };
 
   const updateMenuPressedState = (menu, attribute, activeValue) => {
@@ -463,6 +572,9 @@
       }
     });
 
+    updateDeliveryOptionLabels(nextLang);
+    syncSelectedDeliveryLabel();
+    updateDeliveryDisplay();
     updateFabLabels();
     updateFabMenuSelection();
     updateProductPrices();
@@ -876,9 +988,26 @@
 
   chipButtons.forEach((chip) => {
     chip.addEventListener('click', () => {
-      chipButtons.forEach((btn) => btn.setAttribute('aria-pressed', String(btn === chip)));
+      setSelectedDeliveryTime(chip);
     });
   });
+
+  if (checkoutTrigger) {
+    checkoutTrigger.addEventListener('click', () => {
+      closeMenus();
+      closeAllDrawers();
+      resetFabStates();
+      if (payDrawer) {
+        openDrawer(payDrawer);
+      }
+      if (fabPay) {
+        fabPay.setAttribute('aria-pressed', 'true');
+        if (isSmallScreen()) {
+          showFabLabel(fabPay);
+        }
+      }
+    });
+  }
 
   if (orderButton && orderSection) {
     orderButton.addEventListener('click', () => {
@@ -888,6 +1017,7 @@
 
   initializeCart();
   restorePreferences();
+  restoreDeliverySelection();
   applyDrawerLayout();
   updateCarousel();
   setCopyright();


### PR DESCRIPTION
## Summary
- add metadata to delivery time chips and surface the selected estimate in the order summary and payment drawer
- extend the localization and persistence logic for delivery selections, including storing the preferred option
- open the payment summary drawer when "Checkout seguro" is pressed to tie the button to the FAB checkout flow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da588db954832b9ecd266ded5ae4d6