### PR TITLE
Add clear cart controls to checkout

### DIFF
--- a/index.html
+++ b/index.html
@@ -424,6 +424,15 @@
             <button type="button" class="chip" aria-pressed="false">1 hr 30 min</button>
           </div>
         </div>
+        <div class="order-actions">
+          <button
+            type="button"
+            class="button button--ghost"
+            data-action="clear-cart"
+            data-i18n="clearOrder"
+            disabled
+          >Clear</button>
+        </div>
         <button type="button" class="button button--primary" data-i18n="checkout">Secure checkout</button>
       </article>
     </section>
@@ -484,7 +493,18 @@
       <div class="drawer__body">
         <ul class="payment-list" data-payment-items aria-live="polite"></ul>
         <p class="payment-list__empty" data-payment-empty data-i18n="orderSummaryEmpty">Your basket is empty. Add menu favorites to see them here.</p>
-        <p class="payment-list__total"><strong data-i18n="ordersTotal">Total</strong>: <span data-payment-total>$0.00</span></p>
+        <p class="payment-list__total">
+          <span class="payment-list__total-amount">
+            <strong data-i18n="ordersTotal">Total</strong>: <span data-payment-total>$0.00</span>
+          </span>
+          <button
+            type="button"
+            class="button button--ghost button--ghost--compact"
+            data-action="clear-cart"
+            data-i18n="clearOrder"
+            disabled
+          >Clear</button>
+        </p>
         <button type="button" class="button button--primary" data-i18n="payNow">Pay now</button>
       </div>
     </div>

--- a/main.css
+++ b/main.css
@@ -255,8 +255,35 @@ body {
   transition: transform var(--transition), box-shadow var(--transition), filter var(--transition);
 }
 
+.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+  filter: none;
+}
+
 .button--primary {
   width: 100%;
+}
+
+.button--ghost {
+  background: transparent;
+  color: var(--accent-strong);
+  border: 1.5px solid currentColor;
+  box-shadow: none;
+  padding: 0.6rem 1.75rem;
+  width: auto;
+}
+
+.button--ghost:disabled {
+  opacity: 0.35;
+}
+
+.button--ghost:hover,
+.button--ghost:focus-visible {
+  background: var(--accent);
+  color: #101319;
+  border-color: transparent;
 }
 
 .cta:hover,
@@ -720,6 +747,14 @@ body {
   margin: 0;
 }
 
+.order-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 0.25rem;
+}
+
 .delivery-time {
   display: grid;
   gap: 0.75rem;
@@ -1048,6 +1083,22 @@ body {
   margin: 0.5rem 0 0;
   font-size: 1.05rem;
   color: var(--text-main);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.payment-list__total-amount {
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+}
+
+.button--ghost--compact {
+  padding: 0.4rem 1.2rem;
+  font-size: 0.95rem;
 }
 
 @media (min-width: 900px) {

--- a/main.js
+++ b/main.js
@@ -34,6 +34,7 @@
   const paymentList = document.querySelector('[data-payment-items]');
   const paymentEmpty = document.querySelector('[data-payment-empty]');
   const paymentTotal = document.querySelector('[data-payment-total]');
+  const clearCartButtons = Array.from(document.querySelectorAll('[data-action="clear-cart"]'));
   const smallScreenQuery = window.matchMedia('(max-width: 767px)');
   const largeScreenQuery = window.matchMedia('(min-width: 900px)');
   const draggableDrawerIds = new Set(['chatDrawer', 'payDrawer']);
@@ -75,6 +76,7 @@
       orderItems: 'Selected items',
       orderSummaryEmpty: 'Your basket is empty. Add menu favorites to see them here.',
       deliveryTitle: 'Delivery time',
+      clearOrder: 'Clear',
       checkout: 'Secure checkout',
       carouselPrev: 'Previous favorites',
       carouselNext: 'Next favorites',
@@ -125,6 +127,7 @@
       orderItems: 'Artículos seleccionados',
       orderSummaryEmpty: 'Tu pedido está vacío. Agrega favoritos del menú para verlos aquí.',
       deliveryTitle: 'Tiempo de entrega',
+      clearOrder: 'Vaciar',
       checkout: 'Checkout seguro',
       carouselPrev: 'Favoritos anteriores',
       carouselNext: 'Más favoritos',
@@ -309,6 +312,12 @@
       paymentTotal.textContent = formatCurrency(total);
     }
 
+    clearCartButtons.forEach((button) => {
+      if (button) {
+        button.toggleAttribute('disabled', !hasItems);
+      }
+    });
+
     productCards.forEach((card) => {
       const name = card.dataset.name;
       const entry = name ? cart.get(name) : undefined;
@@ -328,6 +337,17 @@
     }
     entry.quantity = Math.max(0, entry.quantity + delta);
     cart.set(name, entry);
+    updateCartDisplay();
+  };
+
+  const clearCart = () => {
+    cart.forEach((entry, name) => {
+      if (!entry) {
+        return;
+      }
+      entry.quantity = 0;
+      cart.set(name, entry);
+    });
     updateCartDisplay();
   };
 
@@ -401,7 +421,7 @@
     updateFabMenuSelection();
     if (themeToggle) {
       const isDark = nextTheme === 'dark';
-      themeToggle.textContent = isDark ? 'Light [Sun]' : 'Dark [Moon]';
+      themeToggle.textContent = isDark ? 'Light' : 'Dark';
       themeToggle.setAttribute('aria-label', isDark ? 'Switch to light theme' : 'Switch to dark theme');
       themeToggle.setAttribute('aria-pressed', String(isDark));
     }
@@ -872,6 +892,16 @@
         }
       });
     }
+  });
+
+  clearCartButtons.forEach((button) => {
+    if (!button) {
+      return;
+    }
+    button.addEventListener('click', () => {
+      clearCart();
+      button.blur();
+    });
   });
 
   chipButtons.forEach((chip) => {


### PR DESCRIPTION
## Summary
- remove the decorative sun and moon bracket labels from the theme toggle
- add "Clear" cart controls beneath the delivery time chips and inside the payment drawer, including styling and translations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da55555018832b996624b53f588756