### PR TITLE
Align clear button with payment total summary

### DIFF
--- a/main.css
+++ b/main.css
@@ -1139,17 +1139,21 @@ body {
   margin: 0.5rem 0 0;
   font-size: 1.05rem;
   color: var(--text-main);
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
-  justify-content: space-between;
   gap: 0.75rem;
-  flex-wrap: wrap;
 }
 
 .payment-list__total-amount {
   display: flex;
   align-items: baseline;
   gap: 0.35rem;
+  min-width: 0;
+}
+
+.payment-list__total .button {
+  justify-self: end;
 }
 
 .button--ghost--compact {


### PR DESCRIPTION
## Summary
- update the payment summary total row to use a two-column grid so the Clear button sits beside the total amount
- keep the total label responsive by preventing it from shrinking while leaving the button aligned to the right

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da61731c50832ba70ec4eb278a2f04