### PR TITLE
Restore carousel navigation for Our menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,23 +77,26 @@
           <button
             class="accordion__trigger"
             type="button"
-            aria-expanded="false"
+            aria-expanded="true"
             aria-controls="seasonalFavorites"
             id="order-title">
             <span data-i18n="orderTitle">Our menu</span>
             <span class="accordion__icon" aria-hidden="true">▾</span>
           </button>
         </h2>
-        <div class="accordion__content" id="seasonalFavorites" role="region" aria-labelledby="order-title" hidden>
+        <div class="accordion__content" id="seasonalFavorites" role="region" aria-labelledby="order-title">
           <p class="accordion__description" data-i18n="orderSubtitle">Tap to explore our handcrafted favorites.</p>
           <div class="product-carousel" data-carousel>
             <button
-              class="carousel__control carousel__control--prev"
+              class="product-carousel__control product-carousel__control--prev"
               type="button"
+              data-carousel-prev
               aria-label="Previous favorites"
-              data-i18n-attr="aria-label"
               data-i18n="carouselPrev"
-              data-i18n-skip-text="true">
+              data-i18n-attr="aria-label"
+              data-i18n-skip-text="true"
+            >
+              <span aria-hidden="true">&#8249;</span>
             </button>
             <div class="product-carousel__viewport">
               <ul class="product-carousel__track">
@@ -111,10 +114,10 @@
                     <p class="product-card__meta">Tueste medio · 12 oz</p>
                   </div>
                   <div class="product-card__footer">
-                    <span class="product-card__price" aria-label="Price">$0.60</span>
-                    <div class="product-card__controls">
+                    <div class="product-card__actions">
                       <button type="button" class="product-card__button" data-cart="add" data-i18n="addToOrder">+ Add</button>
-                      <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder">- Remove</button>
+                      <span class="product-card__price" aria-label="Price">$0.60</span>
+                      <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder" disabled>- Remove</button>
                     </div>
                     <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
                   </div>
@@ -133,10 +136,10 @@
                     <p class="product-card__meta">Café + tortilla + huevos + salchicha</p>
                   </div>
                   <div class="product-card__footer">
-                    <span class="product-card__price" aria-label="Price">$3.20</span>
-                    <div class="product-card__controls">
+                    <div class="product-card__actions">
                       <button type="button" class="product-card__button" data-cart="add" data-i18n="addToOrder">+ Add</button>
-                      <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder">- Remove</button>
+                      <span class="product-card__price" aria-label="Price">$3.20</span>
+                      <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder" disabled>- Remove</button>
                     </div>
                     <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
                   </div>
@@ -155,10 +158,10 @@
                     <p class="product-card__meta">4 porciones</p>
                   </div>
                   <div class="product-card__footer">
-                    <span class="product-card__price" aria-label="Price">$1.60</span>
-                    <div class="product-card__controls">
+                    <div class="product-card__actions">
                       <button type="button" class="product-card__button" data-cart="add" data-i18n="addToOrder">+ Add</button>
-                      <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder">- Remove</button>
+                      <span class="product-card__price" aria-label="Price">$1.60</span>
+                      <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder" disabled>- Remove</button>
                     </div>
                     <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
                   </div>
@@ -177,10 +180,10 @@
                     <p class="product-card__meta">1 huevo frito + 1 salchicha</p>
                   </div>
                   <div class="product-card__footer">
-                    <span class="product-card__price" aria-label="Price">$2.00</span>
-                    <div class="product-card__controls">
+                    <div class="product-card__actions">
                       <button type="button" class="product-card__button" data-cart="add" data-i18n="addToOrder">+ Add</button>
-                      <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder">- Remove</button>
+                      <span class="product-card__price" aria-label="Price">$2.00</span>
+                      <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder" disabled>- Remove</button>
                     </div>
                     <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
                   </div>
@@ -199,10 +202,10 @@
                     <p class="product-card__meta">Botella 355 ml</p>
                   </div>
                   <div class="product-card__footer">
-                    <span class="product-card__price" aria-label="Price">$0.60</span>
-                    <div class="product-card__controls">
+                    <div class="product-card__actions">
                       <button type="button" class="product-card__button" data-cart="add" data-i18n="addToOrder">+ Add</button>
-                      <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder">- Remove</button>
+                      <span class="product-card__price" aria-label="Price">$0.60</span>
+                      <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder" disabled>- Remove</button>
                     </div>
                     <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
                   </div>
@@ -221,10 +224,10 @@
                     <p class="product-card__meta">Botella 355 ml</p>
                   </div>
                   <div class="product-card__footer">
-                    <span class="product-card__price" aria-label="Price">$0.60</span>
-                    <div class="product-card__controls">
+                    <div class="product-card__actions">
                       <button type="button" class="product-card__button" data-cart="add" data-i18n="addToOrder">+ Add</button>
-                      <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder">- Remove</button>
+                      <span class="product-card__price" aria-label="Price">$0.60</span>
+                      <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder" disabled>- Remove</button>
                     </div>
                     <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
                   </div>
@@ -243,10 +246,10 @@
                     <p class="product-card__meta">Botella 355 ml</p>
                   </div>
                   <div class="product-card__footer">
-                    <span class="product-card__price" aria-label="Price">$0.60</span>
-                    <div class="product-card__controls">
+                    <div class="product-card__actions">
                       <button type="button" class="product-card__button" data-cart="add" data-i18n="addToOrder">+ Add</button>
-                      <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder">- Remove</button>
+                      <span class="product-card__price" aria-label="Price">$0.60</span>
+                      <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder" disabled>- Remove</button>
                     </div>
                     <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
                   </div>
@@ -265,10 +268,10 @@
                     <p class="product-card__meta">Botella 355 ml</p>
                   </div>
                   <div class="product-card__footer">
-                    <span class="product-card__price" aria-label="Price">$0.60</span>
-                    <div class="product-card__controls">
+                    <div class="product-card__actions">
                       <button type="button" class="product-card__button" data-cart="add" data-i18n="addToOrder">+ Add</button>
-                      <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder">- Remove</button>
+                      <span class="product-card__price" aria-label="Price">$0.60</span>
+                      <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder" disabled>- Remove</button>
                     </div>
                     <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
                   </div>
@@ -287,10 +290,10 @@
                     <p class="product-card__meta">Botella 355 ml</p>
                   </div>
                   <div class="product-card__footer">
-                    <span class="product-card__price" aria-label="Price">$0.60</span>
-                    <div class="product-card__controls">
+                    <div class="product-card__actions">
                       <button type="button" class="product-card__button" data-cart="add" data-i18n="addToOrder">+ Add</button>
-                      <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder">- Remove</button>
+                      <span class="product-card__price" aria-label="Price">$0.60</span>
+                      <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder" disabled>- Remove</button>
                     </div>
                     <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
                   </div>
@@ -309,10 +312,10 @@
                     <p class="product-card__meta">Botella 355 ml</p>
                   </div>
                   <div class="product-card__footer">
-                    <span class="product-card__price" aria-label="Price">$0.60</span>
-                    <div class="product-card__controls">
+                    <div class="product-card__actions">
                       <button type="button" class="product-card__button" data-cart="add" data-i18n="addToOrder">+ Add</button>
-                      <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder">- Remove</button>
+                      <span class="product-card__price" aria-label="Price">$0.60</span>
+                      <button type="button" class="product-card__button product-card__button--remove" data-cart="remove" data-i18n="removeFromOrder" disabled>- Remove</button>
                     </div>
                     <span class="product-card__quantity" data-i18n="inCart" data-i18n-count="0" aria-live="polite">In cart: 0</span>
                   </div>
@@ -320,12 +323,15 @@
               </ul>
             </div>
             <button
-              class="carousel__control carousel__control--next"
+              class="product-carousel__control product-carousel__control--next"
               type="button"
+              data-carousel-next
               aria-label="Next favorites"
-              data-i18n-attr="aria-label"
               data-i18n="carouselNext"
-              data-i18n-skip-text="true">
+              data-i18n-attr="aria-label"
+              data-i18n-skip-text="true"
+            >
+              <span aria-hidden="true">&#8250;</span>
             </button>
           </div>
         </div>

--- a/main.css
+++ b/main.css
@@ -403,15 +403,18 @@ body {
 }
 
 .product-carousel {
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  align-items: center;
-  gap: 1rem;
+  --carousel-gap: clamp(1rem, 4vw, 1.5rem);
   position: relative;
+  display: grid;
+  place-items: center;
+  max-width: min(720px, 100%);
+  margin-inline: auto;
 }
 
 .product-carousel__viewport {
   overflow: hidden;
+  width: 100%;
+  padding-inline: clamp(0.5rem, 4vw, 1.5rem);
 }
 
 .product-carousel__track {
@@ -419,36 +422,62 @@ body {
   padding: 0;
   margin: 0;
   display: flex;
-  gap: 1.5rem;
-  transition: transform var(--transition);
+  gap: var(--carousel-gap);
+  transition: transform 0.45s ease;
+  will-change: transform;
 }
 
-.carousel__control {
+.product-carousel__control {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
   border: none;
-  background: var(--accent);
-  color: #101319;
-  font-size: 2rem;
-  line-height: 1;
+  border-radius: 999px;
   width: 48px;
   height: 48px;
-  border-radius: 50%;
-  cursor: pointer;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: transform var(--transition), box-shadow var(--transition), opacity var(--transition);
-  box-shadow: 0 12px 24px rgba(39, 46, 48, 0.18);
+  background: var(--surface);
+  color: var(--chip-text);
+  box-shadow: 0 12px 30px rgba(31, 27, 44, 0.16);
+  cursor: pointer;
+  transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+  z-index: 2;
 }
 
-.carousel__control[disabled] {
+.product-carousel__control:hover,
+.product-carousel__control:focus-visible {
+  transform: translateY(-50%) translateY(-2px);
+  box-shadow: 0 16px 34px rgba(31, 27, 44, 0.22);
+  outline: none;
+}
+
+.product-carousel__control:active {
+  transform: translateY(-50%) translateY(1px);
+}
+
+.product-carousel__control[disabled] {
   opacity: 0.4;
   cursor: not-allowed;
   box-shadow: none;
 }
 
-.carousel__control:hover:not([disabled]),
-.carousel__control:focus-visible:not([disabled]) {
-  transform: translateY(-2px);
+.product-carousel__control--prev {
+  left: clamp(0.75rem, 2.5vw, 1.75rem);
+}
+
+.product-carousel__control--next {
+  right: clamp(0.75rem, 2.5vw, 1.75rem);
+}
+
+.product-carousel__control span {
+  font-size: 1.6rem;
+  line-height: 1;
+}
+
+.product-carousel--static .product-carousel__control {
+  display: none;
 }
 
 .product-card {
@@ -458,7 +487,9 @@ body {
   display: flex;
   flex-direction: column;
   gap: 0.9rem;
-  min-width: clamp(200px, 80vw, 280px);
+  flex: 0 0 calc(100% - var(--carousel-gap));
+  max-width: 340px;
+  min-width: 260px;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18);
   transition: transform var(--transition), box-shadow var(--transition);
 }
@@ -497,22 +528,23 @@ body {
 
 .product-card__footer {
   display: grid;
-  gap: 0.6rem;
+  gap: 0.75rem;
+}
+
+.product-card__actions {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .product-card__price {
   font-weight: 700;
   font-size: 1.05rem;
-}
-
-.product-card__controls {
-  display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
+  text-align: center;
 }
 
 .product-card__button {
-  flex: 1 1 120px;
   border: none;
   border-radius: 999px;
   padding: 0.55rem 1rem;
@@ -521,6 +553,10 @@ body {
   background: var(--chip-bg);
   color: var(--chip-text);
   transition: background var(--transition), color var(--transition), transform var(--transition);
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
 }
 
 .product-card__button:hover,
@@ -1261,45 +1297,24 @@ body {
 }
 
 @media (max-width: 768px) {
-  .product-carousel {
-    grid-template-columns: 1fr;
-    gap: 0.75rem;
-  }
-
   .product-carousel__viewport {
-    overflow: hidden;
-    padding-inline: 3.5rem;
-  }
-
-  .product-carousel__track {
-    gap: 1rem;
+    padding-inline: clamp(0.75rem, 8vw, 2rem);
   }
 
   .product-card {
-    flex: 0 0 100%;
-    max-width: 100%;
-    min-width: auto;
+    flex-basis: calc(100% - var(--carousel-gap));
+    max-width: 360px;
+    min-width: 240px;
+  }
+}
+
+@media (min-width: 900px) {
+  .product-carousel__viewport {
+    padding-inline: clamp(1rem, 4vw, 2.5rem);
   }
 
-  .carousel__control {
-    position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
-    width: 44px;
-    height: 44px;
-    font-size: 1.6rem;
-  }
-
-  .carousel__control:hover:not([disabled]),
-  .carousel__control:focus-visible:not([disabled]) {
-    transform: translateY(calc(-50% - 2px));
-  }
-
-  .carousel__control--prev {
-    left: 0.75rem;
-  }
-
-  .carousel__control--next {
-    right: 0.75rem;
+  .product-card {
+    flex-basis: calc((100% - var(--carousel-gap)) / 2);
+    max-width: 320px;
   }
 }

--- a/main.js
+++ b/main.js
@@ -18,9 +18,8 @@
   const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
   const carousel = document.querySelector('[data-carousel]');
   const carouselTrack = document.querySelector('.product-carousel__track');
-  const carouselViewport = document.querySelector('.product-carousel__viewport');
-  const carouselPrev = document.querySelector('.carousel__control--prev');
-  const carouselNext = document.querySelector('.carousel__control--next');
+  const carouselPrevButton = carousel ? carousel.querySelector('[data-carousel-prev]') : null;
+  const carouselNextButton = carousel ? carousel.querySelector('[data-carousel-next]') : null;
   const accordionTrigger = document.querySelector('.accordion__trigger');
   const accordionContent = document.querySelector('.accordion__content');
   const productCards = Array.from(document.querySelectorAll('.product-card'));
@@ -49,6 +48,7 @@
   const DELIVERY_STORAGE_KEY = 'marxia-delivery-minutes';
   let currentSlideIndex = 0;
   let maxSlideIndex = 0;
+  let lastCarouselPerView = largeScreenQuery.matches ? 2 : 1;
   let currentLanguage = html.lang === 'es' ? 'es' : 'en';
   let selectedDeliveryTime = null;
   const translations = {
@@ -166,6 +166,63 @@
 
   const isSmallScreen = () => smallScreenQuery.matches;
   const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+  const getCardsPerView = () => (largeScreenQuery.matches ? 2 : 1);
+
+  const getCarouselGap = () => {
+    if (!carouselTrack) {
+      return 0;
+    }
+    const style = window.getComputedStyle(carouselTrack);
+    const gapValue =
+      style.columnGap || style.gap || style.rowGap || style.getPropertyValue('--carousel-gap');
+    const parsed = Number.parseFloat(gapValue);
+    return Number.isFinite(parsed) ? parsed : 0;
+  };
+
+  const updateCarouselControls = () => {
+    if (carouselPrevButton) {
+      carouselPrevButton.disabled = currentSlideIndex <= 0;
+    }
+    if (carouselNextButton) {
+      carouselNextButton.disabled = currentSlideIndex >= maxSlideIndex;
+    }
+    if (carousel) {
+      carousel.classList.toggle('product-carousel--static', maxSlideIndex === 0);
+    }
+  };
+
+  const getCarouselStep = () => {
+    if (!carouselTrack) {
+      return 0;
+    }
+    const perView = getCardsPerView();
+    const startIndex = Math.min(currentSlideIndex * perView, Math.max(productCards.length - 1, 0));
+    const firstVisibleCard = productCards[startIndex] || productCards[0];
+    if (!firstVisibleCard) {
+      return 0;
+    }
+    const cardWidth = firstVisibleCard.getBoundingClientRect().width;
+    const gap = getCarouselGap();
+    return perView * cardWidth + Math.max(0, (perView - 1) * gap);
+  };
+
+  const updateCarouselPosition = () => {
+    if (!carouselTrack) {
+      return;
+    }
+    const step = getCarouselStep();
+    const offset = step * currentSlideIndex;
+    carouselTrack.style.transform = step > 0 ? `translateX(-${offset}px)` : 'translateX(0)';
+  };
+
+  const moveCarousel = (direction) => {
+    if (maxSlideIndex <= 0) {
+      return;
+    }
+    currentSlideIndex = clamp(currentSlideIndex + direction, 0, maxSlideIndex);
+    updateCarouselPosition();
+    updateCarouselControls();
+  };
 
   const getLocale = () => (currentLanguage === 'es' ? 'es-EC' : 'en-US');
 
@@ -523,31 +580,22 @@
   };
 
   const updateCarousel = () => {
-    if (!carousel || !carouselTrack || !carouselViewport || productCards.length === 0) {
+    if (!carousel || !carouselTrack) {
       return;
     }
-    const styles = window.getComputedStyle(carouselTrack);
-    const gapValue = Number.parseFloat(styles.columnGap || styles.gap || '0') || 0;
-    const cardWidth = productCards[0].getBoundingClientRect().width;
-    const viewportWidth = carouselViewport.getBoundingClientRect().width;
-    const totalSlideWidth = cardWidth + gapValue;
-    if (!Number.isFinite(totalSlideWidth) || totalSlideWidth <= 0) {
-      return;
+    const totalCards = productCards.length;
+    const perView = getCardsPerView();
+    if (perView !== lastCarouselPerView) {
+      currentSlideIndex = Math.floor((currentSlideIndex * lastCarouselPerView) / Math.max(perView, 1));
+      lastCarouselPerView = perView;
     }
-    const prefersSingleSlide = window.matchMedia('(max-width: 768px)').matches;
-    const visibleSlides = prefersSingleSlide
-      ? 1
-      : Math.max(1, Math.floor((viewportWidth + gapValue) / totalSlideWidth));
-    maxSlideIndex = Math.max(0, productCards.length - visibleSlides);
-    currentSlideIndex = Math.min(currentSlideIndex, maxSlideIndex);
-    const offset = currentSlideIndex * totalSlideWidth;
-    carouselTrack.style.transform = `translateX(-${offset}px)`;
-    if (carouselPrev) {
-      carouselPrev.toggleAttribute('disabled', currentSlideIndex === 0);
-    }
-    if (carouselNext) {
-      carouselNext.toggleAttribute('disabled', currentSlideIndex >= maxSlideIndex);
-    }
+    const nextMaxIndex = Math.max(0, Math.ceil(totalCards / perView) - 1);
+    maxSlideIndex = nextMaxIndex;
+    currentSlideIndex = clamp(currentSlideIndex, 0, maxSlideIndex);
+    window.requestAnimationFrame(() => {
+      updateCarouselPosition();
+      updateCarouselControls();
+    });
   };
   const setCopyright = () => {
     if (copyright) {
@@ -981,10 +1029,30 @@
     }
   });
 
+  if (carouselPrevButton) {
+    carouselPrevButton.addEventListener('click', () => moveCarousel(-1));
+  }
+
+  if (carouselNextButton) {
+    carouselNextButton.addEventListener('click', () => moveCarousel(1));
+  }
+
   if (typeof largeScreenQuery.addEventListener === 'function') {
     largeScreenQuery.addEventListener('change', applyDrawerLayout);
+    largeScreenQuery.addEventListener('change', () => {
+      updateCarousel();
+    });
   } else if (typeof largeScreenQuery.addListener === 'function') {
     largeScreenQuery.addListener(applyDrawerLayout);
+    largeScreenQuery.addListener(updateCarousel);
+  }
+
+  if (typeof smallScreenQuery.addEventListener === 'function') {
+    smallScreenQuery.addEventListener('change', () => {
+      updateCarousel();
+    });
+  } else if (typeof smallScreenQuery.addListener === 'function') {
+    smallScreenQuery.addListener(updateCarousel);
   }
 
   if (accordionTrigger && accordionContent) {
@@ -1010,24 +1078,6 @@
     if (!accordionContent.hidden) {
       refreshCarouselLayout();
     }
-  }
-
-  if (carouselPrev) {
-    carouselPrev.addEventListener('click', () => {
-      if (currentSlideIndex > 0) {
-        currentSlideIndex -= 1;
-        updateCarousel();
-      }
-    });
-  }
-
-  if (carouselNext) {
-    carouselNext.addEventListener('click', () => {
-      if (currentSlideIndex < maxSlideIndex) {
-        currentSlideIndex += 1;
-        updateCarousel();
-      }
-    });
   }
 
   window.addEventListener('resize', () => {

--- a/rectangle-image-description.md
+++ b/rectangle-image-description.md
@@ -1,0 +1,11 @@
+# Rectangle-Based Layout Description
+
+The annotated screenshot highlights a portion of a food ordering interface structured around rectangular cards and controls:
+
+- Two product cards sit side by side within bold green outlines. Each card features a breakfast item composed of a tortilla and eggs, accompanied by descriptive text, price, and action buttons.
+- Within each green rectangle, a thinner red rectangle surrounds the photograph of the meal, emphasizing the round tortilla served on a small plate. The left card also shows a sausage link and salsa, while the right card displays only the tortilla.
+- Orange circular arrow buttons appear on the far left and right of the frame, suggesting horizontal carousel navigation between menu items.
+- At the bottom of each card, a pale cream panel contains quantity controls with orange “Agregar” (add) and “Quitar” (remove) buttons. Beneath the panel, a wide green rectangle encloses the text “En carrito: 0,” indicating the current cart count for the item.
+- A purple plus symbol positioned near the bottom right corner and a matching minus symbol near the bottom left corner likely mark the areas associated with adjusting the quantity controls.
+
+Overall, the rectangles draw attention to the layout hierarchy—product imagery, pricing, and cart interactions—within the breakfast menu carousel.


### PR DESCRIPTION
## Summary
- add dedicated previous and next controls to the Our menu carousel with translation-ready labels and graceful disable states
- restyle the product carousel to a flex-based viewport that keeps cards at ~300px while supporting smooth slide animations
- implement responsive JavaScript logic so the carousel shows two items on desktop, one on mobile, and recalculates on resize

## Testing
- manual UI review

------
https://chatgpt.com/codex/tasks/task_e_68db5777ce00832baa66c4977ad91813