### PR TITLE
Ensure FAB labels display on desktop clicks

### DIFF
--- a/main.js
+++ b/main.js
@@ -878,14 +878,12 @@
       fab.setAttribute('aria-pressed', String(!isOpen));
     };
 
-    if (isSmallScreen() && !isOpen) {
-      showFabLabel(fab);
+    const shouldDelay = isSmallScreen() && !isOpen;
+    showFabLabel(fab);
+    if (shouldDelay) {
       window.setTimeout(toggle, 220);
     } else {
       toggle();
-      if (isSmallScreen()) {
-        showFabLabel(fab);
-      }
     }
   };
 
@@ -942,14 +940,10 @@
     }
 
     if (target === fabLanguage) {
-      if (isSmallScreen()) {
-        showFabLabel(fabLanguage);
-      }
+      showFabLabel(fabLanguage);
       toggleMenu(document.querySelector('#fabLanguageMenu'), fabLanguage);
     } else if (target === fabTheme) {
-      if (isSmallScreen()) {
-        showFabLabel(fabTheme);
-      }
+      showFabLabel(fabTheme);
       toggleMenu(document.querySelector('#fabThemeMenu'), fabTheme);
     } else if (target === fabChat) {
       toggleFabDrawer(fabChat, 'chatDrawer');


### PR DESCRIPTION
## Summary
- trigger floating action button labels on click across all breakpoints, ensuring language, theme, chat, and cart names appear on large screens
- retain the mobile-only delay before opening drawers so labels remain visible when activating chat or payment drawers

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db5b4ec000832b81669f9c6abe40c3