### PR TITLE
Refine order summary layout

### DIFF
--- a/main.css
+++ b/main.css
@@ -703,32 +703,46 @@ body {
 }
 
 .order-summary__items li {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(2.75rem, auto) auto auto;
+  grid-template-areas: 'label quantity controls price';
   align-items: center;
   gap: 0.5rem;
   background: var(--surface-muted);
-  padding: 0.5rem 0.75rem;
+  padding: 0.5rem 1.25rem 0.5rem 0;
   border-radius: 12px;
   font-size: 0.9rem;
 }
 
 .order-summary__item-label {
-  flex: 1;
+  grid-area: label;
   min-width: 0;
   font-weight: 500;
   white-space: normal;
+  justify-self: start;
+  text-align: left;
+}
+
+.order-summary__item-quantity {
+  grid-area: quantity;
+  min-width: 2.75rem;
+  text-align: center;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  justify-self: center;
 }
 
 .order-summary__controls {
+  grid-area: controls;
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
-  margin-inline: 0.25rem 0.5rem;
+  justify-self: center;
 }
 
 .order-summary__control {
-  width: 1.75rem;
-  height: 1.75rem;
+  min-width: 2.5rem;
+  min-height: 2.5rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -737,8 +751,9 @@ body {
   background: var(--surface);
   color: var(--text-primary);
   font-weight: 600;
-  font-size: 1rem;
+  font-size: clamp(0.75rem, 1vw + 0.5rem, 1.25rem);
   line-height: 1;
+  padding: 0.25rem;
   transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 
@@ -755,9 +770,29 @@ body {
 }
 
 .order-summary__item-price {
-  margin-left: auto;
+  grid-area: price;
+  justify-self: end;
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
+}
+
+@media (max-width: 640px) {
+  .order-summary__items li {
+    grid-template-columns: minmax(0, 1fr) minmax(2.75rem, auto);
+    grid-template-areas:
+      'label quantity'
+      'controls controls'
+      'price price';
+    row-gap: 0.35rem;
+  }
+
+  .order-summary__controls {
+    justify-self: start;
+  }
+
+  .order-summary__item-price {
+    justify-self: end;
+  }
 }
 
 .order-summary__empty,

--- a/main.js
+++ b/main.js
@@ -378,7 +378,12 @@
 
         const label = document.createElement('span');
         label.className = 'order-summary__item-label';
-        label.textContent = `${item.quantity}× ${item.name}`;
+        label.textContent = item.name;
+        label.setAttribute('aria-label', `${item.quantity}× ${item.name}`);
+
+        const quantity = document.createElement('span');
+        quantity.className = 'order-summary__item-quantity';
+        quantity.textContent = `${item.quantity}`;
 
         const controls = document.createElement('div');
         controls.className = 'order-summary__controls';
@@ -409,7 +414,7 @@
         price.className = 'order-summary__item-price';
         price.textContent = formatCurrency(item.price * item.quantity);
 
-        li.append(label, controls, price);
+        li.append(label, quantity, controls, price);
         summaryList.append(li);
       });
       summaryList.toggleAttribute('hidden', !hasItems);


### PR DESCRIPTION
## Summary
- realign order summary item names with the totals column using a grid-based row layout
- center the quantity column, keep controls grouped, and improve mobile stacking for the order summary list

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db5e47ceb4832b8361e4bb89e6015b