### PR TITLE
Improve order summary control sizing

### DIFF
--- a/main.css
+++ b/main.css
@@ -700,46 +700,68 @@ body {
   list-style: none;
   display: grid;
   gap: 0.35rem;
+  --order-summary-control-size: clamp(2.75rem, 2vw + 2.25rem, 3.25rem);
 }
 
 .order-summary__items li {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(var(--order-summary-control-size), auto) auto auto;
+  grid-template-areas: 'label quantity controls price';
   align-items: center;
   gap: 0.5rem;
   background: var(--surface-muted);
-  padding: 0.5rem 0.75rem;
+  padding: 0.5rem 1.25rem 0.5rem 0;
   border-radius: 12px;
   font-size: 0.9rem;
 }
 
 .order-summary__item-label {
-  flex: 1;
+  grid-area: label;
   min-width: 0;
   font-weight: 500;
   white-space: normal;
+  justify-self: start;
+  text-align: left;
+}
+
+.order-summary__item-quantity {
+  grid-area: quantity;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: var(--order-summary-control-size);
+  min-height: var(--order-summary-control-size);
+  text-align: center;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  justify-self: center;
 }
 
 .order-summary__controls {
+  grid-area: controls;
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
-  margin-inline: 0.25rem 0.5rem;
+  gap: 0.5rem;
+  justify-self: center;
+  min-width: calc(var(--order-summary-control-size) * 2 + 0.5rem);
 }
 
 .order-summary__control {
-  width: 1.75rem;
-  height: 1.75rem;
+  min-width: var(--order-summary-control-size);
+  min-height: var(--order-summary-control-size);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   border-radius: 999px;
   border: 1px solid var(--border-subtle);
   background: var(--surface);
-  color: var(--text-primary);
+  color: var(--text-main);
   font-weight: 600;
-  font-size: 1rem;
+  font-size: clamp(1rem, 1vw + 0.85rem, 1.35rem);
   line-height: 1;
+  padding: 0.25rem;
   transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  touch-action: manipulation;
 }
 
 .order-summary__control:hover,
@@ -755,9 +777,29 @@ body {
 }
 
 .order-summary__item-price {
-  margin-left: auto;
+  grid-area: price;
+  justify-self: end;
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
+}
+
+@media (max-width: 640px) {
+  .order-summary__items li {
+    grid-template-columns: minmax(0, 1fr) minmax(var(--order-summary-control-size), auto);
+    grid-template-areas:
+      'label quantity'
+      'controls controls'
+      'price price';
+    row-gap: 0.35rem;
+  }
+
+  .order-summary__controls {
+    justify-self: start;
+  }
+
+  .order-summary__item-price {
+    justify-self: end;
+  }
 }
 
 .order-summary__empty,

--- a/main.js
+++ b/main.js
@@ -378,7 +378,12 @@
 
         const label = document.createElement('span');
         label.className = 'order-summary__item-label';
-        label.textContent = `${item.quantity}× ${item.name}`;
+        label.textContent = item.name;
+        label.setAttribute('aria-label', `${item.quantity}× ${item.name}`);
+
+        const quantity = document.createElement('span');
+        quantity.className = 'order-summary__item-quantity';
+        quantity.textContent = `${item.quantity}`;
 
         const controls = document.createElement('div');
         controls.className = 'order-summary__controls';
@@ -409,7 +414,7 @@
         price.className = 'order-summary__item-price';
         price.textContent = formatCurrency(item.price * item.quantity);
 
-        li.append(label, controls, price);
+        li.append(label, quantity, controls, price);
         summaryList.append(li);
       });
       summaryList.toggleAttribute('hidden', !hasItems);


### PR DESCRIPTION
## Summary
- realign order summary item names with the totals column using a grid-based row layout
- center the quantity column, keep controls grouped, and improve mobile stacking for the order summary list
- standardize the order summary quantity column and control sizing for consistent tap targets on all screens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db5e47ceb4832b8361e4bb89e6015b