### PR TITLE
Fix modal close buttons to handle nested click targets

### DIFF
--- a/main.js
+++ b/main.js
@@ -978,8 +978,9 @@
       applyLanguage(nextLang);
     }
 
-    if (target.matches('[data-close-drawer]')) {
-      const closeTargetId = target.getAttribute('data-close-target');
+    const closeButton = target.closest('[data-close-drawer]');
+    if (closeButton instanceof HTMLElement) {
+      const closeTargetId = closeButton.getAttribute('data-close-target');
       exitAllFabInteractions();
       if (closeTargetId) {
         const associatedFab = document.querySelector(`#${closeTargetId}`);


### PR DESCRIPTION
## Summary
- ensure drawer close buttons use closest detection so clicks on translated labels close the modal
- maintain focus handoff to the associated FAB button after the drawer closes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db839c60c4832b8a3f726fad1d2356