### PR TITLE
Animate seasonal background gradient

### DIFF
--- a/main.css
+++ b/main.css
@@ -58,10 +58,13 @@ body {
     radial-gradient(circle at 88% 22%, rgba(255, 179, 213, 0.28), transparent 46%),
     radial-gradient(circle at 18% 82%, rgba(166, 227, 199, 0.34), transparent 48%),
     linear-gradient(165deg, var(--background-top) 0%, var(--background-middle) 48%, var(--background-bottom) 100%);
+  background-attachment: fixed;
+  background-color: var(--background-middle);
   color: var(--text-main);
   display: flex;
   flex-direction: column;
   position: relative;
+  overflow-x: hidden;
   transition: background var(--transition), color var(--transition);
 }
 
@@ -69,6 +72,83 @@ body {
   background: radial-gradient(circle at 10% 12%, rgba(77, 212, 255, 0.16), transparent 36%),
     radial-gradient(circle at 90% 20%, rgba(126, 243, 179, 0.12), transparent 38%),
     linear-gradient(175deg, var(--background-top) 0%, var(--background-middle) 40%, var(--background-bottom) 100%);
+}
+
+body::before,
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  transition: opacity 6s ease-in-out;
+  will-change: opacity;
+}
+
+body::before {
+  background: radial-gradient(circle at 18% 22%, rgba(255, 196, 124, 0.38), transparent 48%),
+    radial-gradient(circle at 84% 18%, rgba(255, 154, 138, 0.32), transparent 54%),
+    radial-gradient(circle at 22% 82%, rgba(255, 222, 164, 0.26), transparent 56%),
+    linear-gradient(160deg, #ffe8a3 0%, #ffb38a 45%, #ffd5a5 100%);
+  animation: seasonalSummer 28s ease-in-out infinite;
+}
+
+body::after {
+  background: radial-gradient(circle at 22% 25%, rgba(183, 235, 218, 0.45), transparent 52%),
+    radial-gradient(circle at 76% 72%, rgba(255, 196, 253, 0.35), transparent 60%),
+    radial-gradient(circle at 12% 78%, rgba(197, 240, 174, 0.28), transparent 60%),
+    linear-gradient(170deg, #e4f9f5 0%, #ffe6fa 50%, #fef6e4 100%);
+  animation: seasonalSpring 28s ease-in-out infinite;
+  opacity: 0;
+}
+
+@keyframes seasonalSummer {
+  0%,
+  40% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.45;
+  }
+
+  60%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes seasonalSpring {
+  0%,
+  40% {
+    opacity: 0;
+  }
+
+  50% {
+    opacity: 0.55;
+  }
+
+  60%,
+  100% {
+    opacity: 1;
+  }
+}
+
+[data-theme="dark"] body::before,
+[data-theme="dark"] body::after {
+  animation: none;
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body::before,
+  body::after {
+    animation: none;
+  }
+
+  body::after {
+    opacity: 0;
+  }
 }
 
 .skip-link {


### PR DESCRIPTION
## Summary
- add layered pseudo-elements that cycle between summer and spring gradient palettes for the site background
- respect dark theme and reduced-motion preferences while keeping the gradient animation performant

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68db83fa69e8832ba3e152acbadc9f5b