### PR TITLE
Add layered shadows and responsive hover emphasis

### DIFF
--- a/main.css
+++ b/main.css
@@ -8,6 +8,9 @@
   --radius-lg: 28px;
   --radius-md: 20px;
   --shadow-soft: 0 24px 48px rgba(39, 46, 48, 0.12);
+  --shadow-layered: 0 12px 24px rgba(31, 27, 44, 0.08), 0 28px 56px rgba(31, 27, 44, 0.12);
+  --shadow-layered-strong: 0 18px 40px rgba(31, 27, 44, 0.18), 0 34px 68px rgba(31, 27, 44, 0.16);
+  --hover-darken: 0.94;
   --surface: #ffffff;
   --surface-muted: rgba(255, 255, 255, 0.6);
   --surface-strong: rgba(255, 255, 255, 0.86);
@@ -45,6 +48,9 @@
   --toggle-bg: rgba(255, 255, 255, 0.92);
   --toggle-fg: #000000;
   --toggle-shadow: rgba(5, 6, 10, 0.55);
+  --shadow-layered: 0 20px 48px rgba(5, 6, 10, 0.65), 0 32px 72px rgba(5, 6, 10, 0.5);
+  --shadow-layered-strong: 0 26px 62px rgba(5, 6, 10, 0.72), 0 40px 92px rgba(5, 6, 10, 0.65);
+  --hover-darken: 0.88;
 }
 
 * {
@@ -94,7 +100,7 @@ body {
   padding: 0.75rem 1.5rem;
   border-radius: var(--radius-lg);
   background: var(--surface);
-  box-shadow: var(--shadow-soft);
+  box-shadow: var(--shadow-layered);
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -102,6 +108,7 @@ body {
   position: sticky;
   top: 1rem;
   z-index: 9;
+  transition: box-shadow var(--transition), filter var(--transition), transform var(--transition);
 }
 
 .topbar__brand {
@@ -211,10 +218,12 @@ body {
 .hero {
   background: var(--surface);
   border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-soft);
+  box-shadow: var(--shadow-layered);
   padding: clamp(2rem, 5vw, 3rem);
   display: flex;
   justify-content: center;
+  --shape-font-boost: 0px;
+  transition: box-shadow var(--transition), filter var(--transition), transform var(--transition);
 }
 
 .hero__content {
@@ -222,6 +231,14 @@ body {
   text-align: center;
   display: grid;
   gap: 1.25rem;
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: calc(clamp(2.35rem, 5vw, 3.05rem) + var(--shape-font-boost));
+  line-height: 1.1;
+  letter-spacing: 0.01em;
+  transition: font-size var(--transition), letter-spacing var(--transition);
 }
 
 .hero__cta {
@@ -232,13 +249,15 @@ body {
 
 .hero__promise {
   color: var(--text-muted);
-  font-size: 0.95rem;
+  font-size: calc(0.95rem + (var(--shape-font-boost) * 0.3));
+  transition: font-size var(--transition);
 }
 
 .tagline {
-  font-size: clamp(1.1rem, 3vw, 1.35rem);
+  font-size: calc(clamp(1.1rem, 3vw, 1.35rem) + (var(--shape-font-boost) * 0.4));
   color: var(--text-muted);
   margin: 0;
+  transition: font-size var(--transition);
 }
 
 .cta,
@@ -251,7 +270,7 @@ body {
   font-size: 1.05rem;
   font-weight: 600;
   cursor: pointer;
-  box-shadow: var(--shadow-soft);
+  box-shadow: var(--shadow-layered);
   transition: transform var(--transition), box-shadow var(--transition), filter var(--transition);
 }
 
@@ -292,7 +311,8 @@ body {
 .button:hover,
 .button:focus-visible {
   transform: translateY(-2px);
-  filter: brightness(1.05);
+  filter: brightness(var(--hover-darken));
+  box-shadow: var(--shadow-layered-strong);
   outline: none;
 }
 
@@ -321,13 +341,15 @@ body {
   background: var(--surface);
   border-radius: var(--radius-lg);
   padding: clamp(2rem, 4vw, 3rem);
-  box-shadow: var(--shadow-soft);
+  box-shadow: var(--shadow-layered);
   display: grid;
   gap: clamp(1.5rem, 4vw, 2.5rem);
   justify-items: center;
   text-align: center;
   width: min(100%, 960px);
   margin-inline: auto;
+  --shape-font-boost: 0px;
+  transition: box-shadow var(--transition), filter var(--transition), transform var(--transition);
 }
 
 .accordion {
@@ -352,10 +374,10 @@ body {
   color: inherit;
   padding: 1rem 1.5rem;
   border-radius: var(--radius-md);
-  font-size: clamp(1.2rem, 3vw, 1.4rem);
+  font-size: calc(clamp(1.2rem, 3vw, 1.4rem) + (var(--shape-font-boost) * 0.45));
   font-weight: 700;
   cursor: pointer;
-  transition: transform var(--transition), box-shadow var(--transition);
+  transition: transform var(--transition), box-shadow var(--transition), font-size var(--transition);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18);
 }
 
@@ -400,6 +422,8 @@ body {
 .accordion__description {
   margin: 0;
   color: var(--text-muted);
+  font-size: calc(1rem + (var(--shape-font-boost) * 0.3));
+  transition: font-size var(--transition);
 }
 
 .product-carousel {
@@ -440,16 +464,18 @@ body {
   justify-content: center;
   background: var(--surface);
   color: var(--chip-text);
-  box-shadow: 0 12px 30px rgba(31, 27, 44, 0.16);
+  box-shadow: var(--shadow-layered);
   cursor: pointer;
-  transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+  transition: transform var(--transition), box-shadow var(--transition), background var(--transition),
+    filter var(--transition);
   z-index: 2;
 }
 
 .product-carousel__control:hover,
 .product-carousel__control:focus-visible {
   transform: translateY(-50%) translateY(-2px);
-  box-shadow: 0 16px 34px rgba(31, 27, 44, 0.22);
+  box-shadow: var(--shadow-layered-strong);
+  filter: brightness(var(--hover-darken));
   outline: none;
 }
 
@@ -490,8 +516,10 @@ body {
   flex: 0 0 calc(100% - var(--carousel-gap));
   max-width: 340px;
   min-width: 260px;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18);
-  transition: transform var(--transition), box-shadow var(--transition);
+  --product-card-inset-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18);
+  box-shadow: var(--product-card-inset-shadow), var(--shadow-layered);
+  transition: transform var(--transition), box-shadow var(--transition), filter var(--transition);
+  --shape-font-boost: 0px;
 }
 
 .product-card__image {
@@ -507,12 +535,14 @@ body {
 .product-card:hover,
 .product-card:focus-within {
   transform: translateY(-6px);
-  box-shadow: 0 20px 40px rgba(42, 46, 64, 0.22);
+  box-shadow: var(--product-card-inset-shadow), var(--shadow-layered-strong);
+  filter: brightness(var(--hover-darken));
 }
 
 .product-card__info h3 {
   margin: 0;
-  font-size: 1.1rem;
+  font-size: calc(1.1rem + (var(--shape-font-boost) * 0.5));
+  transition: font-size var(--transition);
 }
 
 .product-card__info {
@@ -523,7 +553,8 @@ body {
 .product-card__meta {
   margin: 0;
   color: var(--text-muted);
-  font-size: 0.95rem;
+  font-size: calc(0.95rem + (var(--shape-font-boost) * 0.35));
+  transition: font-size var(--transition);
 }
 
 .product-card__footer {
@@ -540,8 +571,9 @@ body {
 
 .product-card__price {
   font-weight: 700;
-  font-size: 1.05rem;
+  font-size: calc(1.05rem + (var(--shape-font-boost) * 0.4));
   text-align: center;
+  transition: font-size var(--transition);
 }
 
 .product-card__button {
@@ -578,8 +610,9 @@ body {
 }
 
 .product-card__quantity {
-  font-size: 0.9rem;
+  font-size: calc(0.9rem + (var(--shape-font-boost) * 0.3));
   color: var(--text-muted);
+  transition: font-size var(--transition);
 }
 
 .insights {
@@ -607,7 +640,9 @@ body {
   padding: 1.5rem;
   display: grid;
   gap: 1rem;
-  box-shadow: var(--shadow-soft);
+  box-shadow: var(--shadow-layered);
+  --shape-font-boost: 0px;
+  transition: box-shadow var(--transition), filter var(--transition), transform var(--transition);
 }
 
 .panel--orders {
@@ -616,13 +651,15 @@ body {
 
 .panel header h3 {
   margin: 0;
-  font-size: 1.2rem;
+  font-size: calc(1.2rem + (var(--shape-font-boost) * 0.45));
+  transition: font-size var(--transition);
 }
 
 .panel__meta {
   margin: 0;
   color: var(--text-muted);
-  font-size: 0.85rem;
+  font-size: calc(0.85rem + (var(--shape-font-boost) * 0.3));
+  transition: font-size var(--transition);
 }
 
 .sentiment {
@@ -637,22 +674,25 @@ body {
 }
 
 .sentiment__value {
-  font-size: 2.85rem;
+  font-size: calc(2.85rem + (var(--shape-font-boost) * 0.8));
   font-weight: 700;
   color: var(--accent-strong);
+  transition: font-size var(--transition);
 }
 
 .sentiment__label,
 .sentiment__reviews {
   color: var(--text-muted);
   margin: 0;
-  font-size: 0.95rem;
+  font-size: calc(0.95rem + (var(--shape-font-boost) * 0.3));
+  transition: font-size var(--transition);
 }
 
 .sentiment__stars {
-  font-size: 1.35rem;
+  font-size: calc(1.35rem + (var(--shape-font-boost) * 0.35));
   letter-spacing: 0.2rem;
   color: var(--accent);
+  transition: font-size var(--transition);
 }
 
 .line-chart {
@@ -689,8 +729,9 @@ body {
 
 .line-chart figcaption {
   margin: 0;
-  font-size: 0.95rem;
+  font-size: calc(0.95rem + (var(--shape-font-boost) * 0.3));
   color: var(--text-muted);
+  transition: font-size var(--transition);
 }
 
 .panel--orders {
@@ -712,6 +753,8 @@ body {
 .panel--contact p {
   margin: 0;
   color: var(--text-muted);
+  font-size: calc(1rem + (var(--shape-font-boost) * 0.3));
+  transition: font-size var(--transition);
 }
 
 .panel--contact a {
@@ -727,7 +770,8 @@ body {
 
 .order-summary__heading {
   margin: 0;
-  font-size: 1rem;
+  font-size: calc(1rem + (var(--shape-font-boost) * 0.35));
+  transition: font-size var(--transition);
 }
 
 .order-summary__items {
@@ -748,7 +792,8 @@ body {
   background: var(--surface-muted);
   padding: 0.5rem 1.25rem 0.5rem 0;
   border-radius: 12px;
-  font-size: 0.9rem;
+  font-size: calc(0.9rem + (var(--shape-font-boost) * 0.3));
+  transition: font-size var(--transition);
 }
 
 .order-summary__item-label {
@@ -771,6 +816,8 @@ body {
   font-weight: 600;
   font-variant-numeric: tabular-nums;
   justify-self: center;
+  font-size: calc(1rem + (var(--shape-font-boost) * 0.35));
+  transition: font-size var(--transition);
 }
 
 .order-summary__controls {
@@ -793,7 +840,7 @@ body {
   background: var(--surface);
   color: var(--text-main);
   font-weight: 600;
-  font-size: clamp(1rem, 1vw + 0.85rem, 1.35rem);
+  font-size: calc(clamp(1rem, 1vw + 0.85rem, 1.35rem) + (var(--shape-font-boost) * 0.35));
   line-height: 1;
   padding: 0.25rem;
   transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
@@ -842,7 +889,8 @@ body {
 .payment-list__empty {
   margin: 0;
   color: var(--text-muted);
-  font-size: 0.9rem;
+  font-size: calc(0.9rem + (var(--shape-font-boost) * 0.3));
+  transition: font-size var(--transition);
 }
 
 .order-summary {
@@ -856,10 +904,12 @@ body {
   justify-content: space-between;
   align-items: center;
   font-weight: 500;
+  font-size: calc(0.95rem + (var(--shape-font-boost) * 0.3));
+  transition: font-size var(--transition);
 }
 
 .order-summary__total {
-  font-size: 1.1rem;
+  font-size: calc(1.1rem + (var(--shape-font-boost) * 0.45));
 }
 
 .order-summary dt {
@@ -894,8 +944,9 @@ body {
 
 .delivery-time__selection {
   margin: 0;
-  font-size: 0.95rem;
+  font-size: calc(0.95rem + (var(--shape-font-boost) * 0.3));
   color: var(--text-muted);
+  transition: font-size var(--transition);
 }
 
 .chip {
@@ -905,8 +956,10 @@ body {
   background: var(--chip-bg);
   color: var(--chip-text);
   font-weight: 600;
+  font-size: calc(0.95rem + (var(--shape-font-boost) * 0.3));
   cursor: pointer;
-  transition: background var(--transition), color var(--transition), transform var(--transition);
+  transition: background var(--transition), color var(--transition), transform var(--transition),
+    font-size var(--transition);
 }
 
 .chip[aria-pressed="true"] {
@@ -920,7 +973,9 @@ body {
   background: var(--surface);
   border-radius: var(--radius-lg);
   padding: clamp(1.75rem, 4vw, 2.5rem);
-  box-shadow: var(--shadow-soft);
+  box-shadow: var(--shadow-layered);
+  --shape-font-boost: 0px;
+  transition: box-shadow var(--transition), filter var(--transition), transform var(--transition);
 }
 
 .contact h2 {
@@ -931,6 +986,8 @@ body {
 .contact p {
   margin: 0.35rem 0;
   font-weight: 500;
+  font-size: calc(1rem + (var(--shape-font-boost) * 0.35));
+  transition: font-size var(--transition);
 }
 
 .contact a {
@@ -970,10 +1027,10 @@ body {
   height: 54px;
   display: grid;
   place-items: center;
-  box-shadow: var(--shadow-soft);
+  box-shadow: var(--shadow-layered);
   cursor: pointer;
   font-size: 1.4rem;
-  transition: transform var(--transition), filter var(--transition);
+  transition: transform var(--transition), filter var(--transition), box-shadow var(--transition);
 }
 
 .fab {
@@ -1009,7 +1066,7 @@ body {
   letter-spacing: 0.02em;
   padding: 0.35rem 0.65rem;
   border-radius: 999px;
-  box-shadow: var(--shadow-soft);
+  box-shadow: var(--shadow-layered);
   opacity: 0;
   pointer-events: none;
   transition: opacity var(--transition), transform var(--transition);
@@ -1034,18 +1091,19 @@ body {
 .fab-option:hover,
 .fab-option:focus-visible {
   transform: translateY(-2px);
-  filter: brightness(1.05);
+  filter: brightness(var(--hover-darken));
+  box-shadow: var(--shadow-layered-strong);
   outline: none;
 }
 
 .fab-option[aria-pressed="true"] {
   transform: translateY(-2px);
-  filter: brightness(1.1);
-  box-shadow: 0 0 0 3px rgba(16, 19, 25, 0.1) inset, var(--shadow-soft);
+  filter: brightness(var(--hover-darken));
+  box-shadow: 0 0 0 3px rgba(16, 19, 25, 0.12) inset, var(--shadow-layered-strong);
 }
 
 [data-theme="dark"] .fab-option[aria-pressed="true"] {
-  box-shadow: 0 0 0 3px rgba(126, 243, 179, 0.3) inset, var(--shadow-soft);
+  box-shadow: 0 0 0 3px rgba(126, 243, 179, 0.3) inset, var(--shadow-layered-strong);
 }
 
 [data-theme="dark"] .fab,
@@ -1067,7 +1125,7 @@ body {
   background: var(--surface);
   border-radius: var(--radius-md);
   padding: 0.5rem;
-  box-shadow: var(--shadow-soft);
+  box-shadow: var(--shadow-layered);
   display: grid;
   gap: 0.5rem;
   opacity: 0;
@@ -1102,9 +1160,11 @@ body {
   background: var(--surface-strong);
   border-radius: 24px 24px 0 0;
   padding: 1.5rem;
-  box-shadow: var(--shadow-soft);
+  box-shadow: var(--shadow-layered);
   display: grid;
   gap: 1rem;
+  --shape-font-boost: 0px;
+  transition: box-shadow var(--transition), filter var(--transition), transform var(--transition);
 }
 
 .drawer__header {
@@ -1116,6 +1176,8 @@ body {
 
 .drawer__header h2 {
   margin: 0;
+  font-size: calc(1.2rem + (var(--shape-font-boost) * 0.45));
+  transition: font-size var(--transition);
 }
 
 #payDrawer .drawer__header {
@@ -1169,6 +1231,8 @@ body {
   display: grid;
   gap: 1rem;
   color: var(--text-muted);
+  font-size: calc(1rem + (var(--shape-font-boost) * 0.3));
+  transition: font-size var(--transition);
 }
 
 .chat-form {
@@ -1209,22 +1273,27 @@ body {
   background: var(--surface);
   padding: 0.5rem 0.75rem;
   border-radius: 12px;
+  box-shadow: var(--shadow-layered);
+  --shape-font-boost: 0px;
+  transition: box-shadow var(--transition), filter var(--transition), transform var(--transition);
 }
 
 .payment-list__eta {
   margin: 0 0 0.5rem;
-  font-size: 0.95rem;
+  font-size: calc(0.95rem + (var(--shape-font-boost) * 0.3));
   color: var(--text-muted);
+  transition: font-size var(--transition);
 }
 
 .payment-list__total {
   margin: 0.5rem 0 0;
-  font-size: 1.05rem;
+  font-size: calc(1.05rem + (var(--shape-font-boost) * 0.4));
   color: var(--text-main);
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: 0.75rem;
+  transition: font-size var(--transition);
 }
 
 .payment-list__total-amount {
@@ -1232,6 +1301,8 @@ body {
   align-items: baseline;
   gap: 0.35rem;
   min-width: 0;
+  font-size: calc(1.05rem + (var(--shape-font-boost) * 0.4));
+  transition: font-size var(--transition);
 }
 
 .payment-list__total .button {
@@ -1241,6 +1312,44 @@ body {
 .button--ghost--compact {
   padding: 0.4rem 1.2rem;
   font-size: 0.95rem;
+}
+
+@media (min-width: 1024px) and (hover: hover) {
+  .topbar:hover {
+    box-shadow: var(--shadow-layered-strong);
+    filter: brightness(var(--hover-darken));
+    transform: translateY(-4px);
+  }
+
+  .hero:hover,
+  .order:hover,
+  .panel:hover,
+  .contact:hover,
+  .drawer__content:hover {
+    --shape-font-boost: 3px;
+    box-shadow: var(--shadow-layered-strong);
+    filter: brightness(var(--hover-darken));
+    transform: translateY(-6px);
+  }
+
+  .payment-list li:hover {
+    --shape-font-boost: 3px;
+    box-shadow: var(--shadow-layered-strong);
+    filter: brightness(var(--hover-darken));
+    transform: translateY(-4px);
+  }
+
+  .product-card:hover,
+  .product-card:focus-within {
+    --shape-font-boost: 3px;
+  }
+
+  .chip:hover,
+  .chip:focus-visible {
+    --shape-font-boost: 3px;
+    filter: brightness(var(--hover-darken));
+    transform: translateY(-2px);
+  }
 }
 
 @media (min-width: 900px) {


### PR DESCRIPTION
## Summary
- introduce reusable layered shadow variables and apply them to hero, order, panel, and floating actions for deeper depth cues
- add desktop hover treatments that darken surfaces, lift components, and bump typography for a "pop-out" effect
- wire a shared font-boost custom property into hero, menu, analytics, and drawer text so hover interactions enlarge copy consistently

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db85221638832bb5c2bd861e777f97