### PR TITLE
Fix chat drawer close action and remove redundant payment label

### DIFF
--- a/index.html
+++ b/index.html
@@ -536,8 +536,6 @@
           class="drawer__close"
           data-close-drawer
           data-close-target="fabPay"
-          data-i18n="payClose"
-          data-i18n-attr="aria-label"
           aria-label="Close"
         >✕</button>
       </header>

--- a/main.js
+++ b/main.js
@@ -103,7 +103,6 @@
       payTitle: 'Checkout preview',
       payNow: 'Pay now',
       payCloseAction: 'Close',
-      payClose: 'Close payment summary',
       fabLanguageLabel: 'Language options',
       fabThemeLabel: 'Theme options',
       fabChatLabel: 'Live chat',
@@ -160,7 +159,6 @@
       payTitle: 'Resumen de pago',
       payNow: 'Pagar ahora',
       payCloseAction: 'Cerrar',
-      payClose: 'Cerrar resumen de pago',
       fabLanguageLabel: 'Opciones de idioma',
       fabThemeLabel: 'Opciones de tema',
       fabChatLabel: 'Chat en vivo',
@@ -968,8 +966,32 @@
 
     const closeButton = target.closest('[data-close-drawer]');
     if (closeButton instanceof HTMLElement) {
+      event.preventDefault();
       const closeTargetId = closeButton.getAttribute('data-close-target');
-      exitAllFabInteractions();
+      const parentDrawer = closeButton.closest('.drawer');
+
+      if (parentDrawer) {
+        closeDrawer(parentDrawer);
+      }
+
+      closeMenus();
+
+      drawers.forEach((drawer) => {
+        if (drawer !== parentDrawer) {
+          closeDrawer(drawer);
+        }
+      });
+
+      fabButtons.forEach((button) => {
+        if (!(button instanceof HTMLElement)) {
+          return;
+        }
+        button.setAttribute('aria-pressed', 'false');
+        if (button.hasAttribute('aria-expanded')) {
+          button.setAttribute('aria-expanded', 'false');
+        }
+      });
+
       if (closeTargetId) {
         const associatedFab = document.querySelector(`#${closeTargetId}`);
         if (associatedFab instanceof HTMLElement) {
@@ -978,6 +1000,7 @@
           }, 0);
         }
       }
+
       return;
     }
 


### PR DESCRIPTION
## Summary
- remove the payment drawer close button localization so the aria label stays as "Close"
- adjust the drawer close handler to explicitly close drawers and reset floating action buttons, restoring the chat close control

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db97e70318832bb510da2bd077fe71