### PR TITLE
Fix delivery ETA display initialization for menu drawers

### DIFF
--- a/index.html
+++ b/index.html
@@ -457,7 +457,13 @@
               data-label-es="1 hr 30 min"
             >1 hr 30 min</button>
           </div>
-          <p class="delivery-time__selection" data-delivery-selection aria-live="polite" data-i18n-skip-text="true"></p>
+          <p
+            class="delivery-time__selection"
+            data-delivery-selection
+            aria-live="polite"
+            data-i18n-skip-text="true"
+            hidden
+          ></p>
         </div>
         <div class="order-actions">
           <button
@@ -542,6 +548,7 @@
       <div class="drawer__body">
         <ul class="payment-list" data-payment-items aria-live="polite"></ul>
         <p class="payment-list__empty" data-payment-empty data-i18n="orderSummaryEmpty">Your basket is empty. Add menu favorites to see them here.</p>
+        <p class="payment-list__eta" data-payment-delivery aria-live="polite" hidden></p>
         <p class="payment-list__total">
           <span class="payment-list__total-amount">
             <strong data-i18n="ordersTotal">Total</strong>: <span data-payment-total>$0.00</span>

--- a/main.js
+++ b/main.js
@@ -34,6 +34,8 @@
   const paymentList = document.querySelector('[data-payment-items]');
   const paymentEmpty = document.querySelector('[data-payment-empty]');
   const paymentTotal = document.querySelector('[data-payment-total]');
+  const deliverySelectionDisplay = document.querySelector('[data-delivery-selection]');
+  const paymentDeliveryDisplay = document.querySelector('[data-payment-delivery]');
   const clearCartButtons = Array.from(document.querySelectorAll('[data-action="clear-cart"]'));
   const smallScreenQuery = window.matchMedia('(max-width: 767px)');
   const largeScreenQuery = window.matchMedia('(min-width: 900px)');
@@ -80,6 +82,8 @@
       orderItems: 'Selected items',
       orderSummaryEmpty: 'Your basket is empty. Add menu favorites to see them here.',
       deliveryTitle: 'Delivery time',
+      deliveryEta: 'Estimated delivery: {time}',
+      deliveryEtaPrompt: 'Select a delivery window to see your ETA.',
       clearOrder: 'Clear',
       checkout: 'Secure checkout',
       carouselPrev: 'Previous favorites',
@@ -136,6 +140,8 @@
       orderItems: 'Artículos seleccionados',
       orderSummaryEmpty: 'Tu pedido está vacío. Agrega favoritos del menú para verlos aquí.',
       deliveryTitle: 'Tiempo de entrega',
+      deliveryEta: 'Entrega estimada: {time}',
+      deliveryEtaPrompt: 'Selecciona una franja de entrega para ver tu tiempo estimado.',
       clearOrder: 'Vaciar',
       checkout: 'Checkout seguro',
       carouselPrev: 'Favoritos anteriores',


### PR DESCRIPTION
## Summary
- define delivery ETA display elements before use to avoid runtime errors
- add language strings for delivery ETA messaging and hide the prompt until needed
- surface the delivery estimate inside the payment drawer for consistency with the order summary

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68db9aa3c098832b9247278b91e302f2