### PR TITLE
Improve mobile layout spacing and imagery

### DIFF
--- a/main.css
+++ b/main.css
@@ -1661,6 +1661,49 @@ body::after {
   }
 }
 
+@media (max-width: 900px) {
+  html,
+  body {
+    scrollbar-width: none;
+  }
+
+  html::-webkit-scrollbar,
+  body::-webkit-scrollbar {
+    display: none;
+  }
+
+  body {
+    align-items: center;
+  }
+
+  .topbar {
+    display: none;
+  }
+
+  .page {
+    width: min(600px, 90vw);
+    max-width: 90vw;
+    padding: clamp(1.5rem, 6vw, 2.5rem);
+    gap: clamp(2rem, 5vw, 3rem);
+  }
+
+  .page > * {
+    width: 100%;
+  }
+
+  .hero {
+    width: 100%;
+  }
+
+  .product-card {
+    max-width: 100%;
+  }
+
+  .product-card__image {
+    aspect-ratio: 1 / 1;
+  }
+}
+
 @media (max-width: 640px) {
   .topbar {
     margin: 1rem;


### PR DESCRIPTION
## Summary
- hide the header controls and remove scrollbars on mobile and tablet to keep the viewport focused on menu content
- center the main layout within a 90% viewport column for small screens to prevent horizontal drift
- enlarge product imagery on compact devices for better visual emphasis

## Testing
- No automated tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbc4d70b00832baa7a3c5ff49d558a