### PR TITLE
Improve mobile carousel product framing

### DIFF
--- a/index.html
+++ b/index.html
@@ -355,6 +355,15 @@
                 </li>
               </ul>
             </div>
+            <div
+              class="product-carousel__pagination"
+              data-carousel-pagination
+              role="group"
+              aria-label="Menu highlights"
+              data-i18n="carouselPagination"
+              data-i18n-attr="aria-label"
+              hidden
+            ></div>
             <button
               class="product-carousel__control product-carousel__control--next"
               type="button"

--- a/main.css
+++ b/main.css
@@ -603,6 +603,7 @@ body::after {
   transition: transform var(--transition), box-shadow var(--transition), background var(--transition),
     filter var(--transition);
   z-index: 2;
+  touch-action: manipulation;
 }
 
 .product-carousel__control:hover,
@@ -634,6 +635,61 @@ body::after {
 .product-carousel__control span {
   font-size: 1.6rem;
   line-height: 1;
+}
+
+.product-carousel__pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.6rem;
+  width: 100%;
+  margin-top: clamp(0.75rem, 2vw, 1.25rem);
+}
+
+.product-carousel__pagination[hidden] {
+  display: none;
+}
+
+.product-carousel__dot {
+  width: 11px;
+  height: 11px;
+  border-radius: 999px;
+  border: none;
+  background: rgba(31, 27, 44, 0.28);
+  opacity: 0.55;
+  transition: transform var(--transition), background var(--transition), opacity var(--transition),
+    box-shadow var(--transition);
+  cursor: pointer;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  touch-action: manipulation;
+}
+
+.product-carousel__dot.is-active {
+  opacity: 1;
+  transform: scale(1.15);
+  background: var(--accent);
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.55);
+}
+
+[data-theme="dark"] .product-carousel__dot {
+  background: rgba(255, 255, 255, 0.28);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+}
+
+[data-theme="dark"] .product-carousel__dot.is-active {
+  box-shadow: 0 0 0 3px rgba(8, 10, 16, 0.6);
+}
+
+.product-carousel__dot:focus-visible {
+  outline: 2px solid var(--accent-strong);
+  outline-offset: 2px;
+}
+
+.product-carousel__dot[disabled] {
+  cursor: default;
 }
 
 .product-carousel--static .product-carousel__control {
@@ -1728,14 +1784,79 @@ body::after {
 }
 
 @media (max-width: 768px) {
+  .page {
+    padding-inline: clamp(0.75rem, 4vw, 1.5rem);
+  }
+
+  .order {
+    width: min(92vw, 100%);
+    padding: clamp(1.45rem, 5vw, 2.05rem);
+  }
+
+  .accordion {
+    width: 100%;
+  }
+
+  .product-carousel {
+    width: min(92vw, 100%);
+  }
+
   .product-carousel__viewport {
-    padding-inline: clamp(0.5rem, 7vw, 1.5rem);
+    padding-inline: clamp(0.2rem, 2.5vw, 0.65rem);
+  }
+
+  .product-carousel__track {
+    gap: clamp(0.4rem, 2.25vw, 0.7rem);
   }
 
   .product-card {
-    flex-basis: calc(100% - var(--carousel-gap));
-    max-width: 420px;
-    min-width: 260px;
+    --mobile-card-width: min(92vw, 100%);
+    flex: 0 0 var(--mobile-card-width);
+    max-width: var(--mobile-card-width);
+    min-width: var(--mobile-card-width);
+    padding: clamp(1rem, 4vw, 1.35rem);
+    border-radius: clamp(20px, 7vw, 28px);
+  }
+
+  .product-card__image {
+    aspect-ratio: 1;
+    border-radius: clamp(18px, 6vw, 26px);
+  }
+
+  .product-card__footer {
+    gap: clamp(0.85rem, 4vw, 1rem);
+  }
+
+  .product-card__quantity {
+    font-size: clamp(0.85rem, 3.5vw, 0.95rem);
+  }
+
+  .product-carousel__control {
+    width: 44px;
+    height: 44px;
+    background: rgba(31, 27, 44, 0.72);
+    color: #ffffff;
+    box-shadow: 0 12px 28px rgba(31, 27, 44, 0.28);
+    backdrop-filter: blur(8px);
+  }
+
+  [data-theme="dark"] .product-carousel__control {
+    background: rgba(255, 255, 255, 0.18);
+    color: #ffffff;
+    box-shadow: 0 14px 32px rgba(4, 6, 12, 0.55);
+  }
+
+  .product-carousel__control--prev {
+    left: clamp(0.5rem, 4vw, 1rem);
+  }
+
+  .product-carousel__control--next {
+    right: clamp(0.5rem, 4vw, 1rem);
+  }
+
+  .product-carousel__dot {
+    width: 12px;
+    height: 12px;
   }
 }
 


### PR DESCRIPTION
## Summary
- expand the mobile layout padding and container widths so menu cards fill roughly 90% of the viewport while staying centered
- retune carousel viewport spacing, card padding, and image ratios to present the full product photo and pagination controls clearly on phones
- smooth responsive typography inside the card footer so quantity messaging remains legible alongside add/remove buttons

## Testing
- Manual verification of the carousel on a 390px-wide mobile viewport

------
https://chatgpt.com/codex/tasks/task_e_68dd01901b3c832b9677846ec465fdf1