### PR TITLE
Refine mobile carousel layout

### DIFF
--- a/main.css
+++ b/main.css
@@ -1798,19 +1798,25 @@ body::after {
   }
 
   .product-carousel {
-    width: min(92vw, 100%);
+    --mobile-carousel-width: min(98vw, 100%);
+    --mobile-carousel-padding: clamp(0.35rem, 2.75vw, 0.85rem);
+    --mobile-carousel-gap: clamp(0.5rem, 2.75vw, 0.9rem);
+    width: var(--mobile-carousel-width);
+    max-width: var(--mobile-carousel-width);
   }
 
   .product-carousel__viewport {
-    padding-inline: clamp(0.2rem, 2.5vw, 0.65rem);
+    padding-inline: var(--mobile-carousel-padding);
   }
 
   .product-carousel__track {
-    gap: clamp(0.4rem, 2.25vw, 0.7rem);
+    gap: var(--mobile-carousel-gap);
   }
 
   .product-card {
-    --mobile-card-width: min(92vw, 100%);
+    --mobile-card-width: calc(
+      var(--mobile-carousel-width) - (var(--mobile-carousel-padding) * 2)
+    );
     flex: 0 0 var(--mobile-card-width);
     max-width: var(--mobile-card-width);
     min-width: var(--mobile-card-width);
@@ -1819,6 +1825,8 @@ body::after {
   }
 
   .product-card__image {
+    width: 90%;
+    margin-inline: auto;
     aspect-ratio: 1;
     border-radius: clamp(18px, 6vw, 26px);
   }


### PR DESCRIPTION
## Summary
- expand the mobile carousel viewport to 98% width and share padding variables so slides stay centered
- widen mobile product cards and constrain imagery to 90% width for fuller framing without clipping

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd103f3354832b95f4d740ffd8433a