### PR TITLE
Reorder Experience dashboard under order summary

### DIFF
--- a/index.html
+++ b/index.html
@@ -381,63 +381,6 @@
     </section>
 
     <section class="insights" aria-labelledby="insights-title">
-      <header class="section-header">
-        <h2 id="insights-title" data-i18n="insightsTitle">Experience dashboard</h2>
-        <p data-i18n="insightsSubtitle"></p>
-      </header>
-      <div class="insights__grid insights__grid--metrics">
-        <article class="panel" aria-labelledby="sentiment-title">
-          <header>
-            <h3 id="sentiment-title" data-i18n="sentimentTitle">End consumer sentiment</h3>
-            <p class="panel__meta" data-i18n="sentimentUpdated">Updated every 30 minutes</p>
-          </header>
-          <div class="sentiment">
-            <div class="sentiment__score" aria-label="Average rating 4.6 out of 5">
-              <span class="sentiment__value">4.6</span>
-              <span class="sentiment__label" data-i18n="sentimentScore">Average rating</span>
-            </div>
-            <div class="sentiment__stars" role="img" aria-label="4.6 out of 5 stars">
-              ★★★★☆
-            </div>
-            <p class="sentiment__reviews" data-i18n="sentimentReviews">1,248 verified reviews</p>
-          </div>
-        </article>
-
-        <article class="panel" aria-labelledby="visitors-title">
-          <header>
-            <h3 id="visitors-title" data-i18n="visitorsTitle">Visitors</h3>
-            <p class="panel__meta" data-i18n="visitorsMeta">Foot &amp; site traffic</p>
-          </header>
-          <figure class="line-chart" aria-describedby="visitors-stats">
-            <svg viewBox="0 0 240 120" role="img" aria-labelledby="visitors-title">
-              <polyline class="line-chart__grid" points="0,100 240,100"></polyline>
-              <polyline class="line-chart__line" points="0,90 40,80 80,85 120,60 160,65 200,40 240,45"></polyline>
-            </svg>
-            <figcaption id="visitors-stats" data-i18n="visitorsCaption">Today 320 · This month 8,450 · Last year 92,300</figcaption>
-          </figure>
-        </article>
-
-        <article class="panel" aria-labelledby="sales-title">
-          <header>
-            <h3 id="sales-title" data-i18n="salesTitle">Online sales</h3>
-            <p class="panel__meta" data-i18n="salesMeta">Room to grow</p>
-          </header>
-          <figure class="line-chart" aria-describedby="sales-stats">
-            <svg viewBox="0 0 240 120" role="img" aria-labelledby="sales-title">
-              <polyline class="line-chart__grid" points="0,100 240,100"></polyline>
-              <polyline class="line-chart__line line-chart__line--accent" points="0,95 40,90 80,70 120,60 160,55 200,35 240,25"></polyline>
-            </svg>
-            <figcaption id="sales-stats" data-i18n="salesCaption">Today $620 · This month $18,400 · Last year $212,000</figcaption>
-          </figure>
-        </article>
-      </div>
-
-      <article class="panel panel--contact" aria-labelledby="contact-title">
-        <h3 id="contact-title" data-i18n="contactTitle">We deliver to</h3>
-        <p data-i18n="contactAreas">Saucés · Alborada · Guayacanes · Tarazana · Brisas del Río</p>
-        <p data-i18n="contactWhatsApp">WhatsApp <a href="https://wa.me/593987654321">+593 958 741 463</a></p>
-      </article>
-
       <article class="panel panel--orders" aria-labelledby="orders-title">
         <header>
           <h3 id="orders-title" data-i18n="ordersTitle">Order details</h3>
@@ -510,6 +453,63 @@
           >Clear</button>
         </div>
         <button type="button" class="button button--primary" data-i18n="checkout">Secure checkout</button>
+      </article>
+
+      <header class="section-header">
+        <h2 id="insights-title" data-i18n="insightsTitle">Experience dashboard</h2>
+        <p data-i18n="insightsSubtitle"></p>
+      </header>
+      <div class="insights__grid insights__grid--metrics">
+        <article class="panel panel--metric" aria-labelledby="sentiment-title">
+          <header>
+            <h3 id="sentiment-title" data-i18n="sentimentTitle">End consumer sentiment</h3>
+            <p class="panel__meta" data-i18n="sentimentUpdated">Updated every 30 minutes</p>
+          </header>
+          <div class="sentiment">
+            <div class="sentiment__score" aria-label="Average rating 4.6 out of 5">
+              <span class="sentiment__value">4.6</span>
+              <span class="sentiment__label" data-i18n="sentimentScore">Average rating</span>
+            </div>
+            <div class="sentiment__stars" role="img" aria-label="4.6 out of 5 stars">
+              ★★★★☆
+            </div>
+            <p class="sentiment__reviews" data-i18n="sentimentReviews">1,248 verified reviews</p>
+          </div>
+        </article>
+
+        <article class="panel panel--metric" aria-labelledby="visitors-title">
+          <header>
+            <h3 id="visitors-title" data-i18n="visitorsTitle">Visitors</h3>
+            <p class="panel__meta" data-i18n="visitorsMeta">Foot &amp; site traffic</p>
+          </header>
+          <figure class="line-chart" aria-describedby="visitors-stats">
+            <svg viewBox="0 0 240 120" role="img" aria-labelledby="visitors-title">
+              <polyline class="line-chart__grid" points="0,100 240,100"></polyline>
+              <polyline class="line-chart__line" points="0,90 40,80 80,85 120,60 160,65 200,40 240,45"></polyline>
+            </svg>
+            <figcaption id="visitors-stats" data-i18n="visitorsCaption">Today 320 · This month 8,450 · Last year 92,300</figcaption>
+          </figure>
+        </article>
+
+        <article class="panel panel--metric" aria-labelledby="sales-title">
+          <header>
+            <h3 id="sales-title" data-i18n="salesTitle">Online sales</h3>
+            <p class="panel__meta" data-i18n="salesMeta">Room to grow</p>
+          </header>
+          <figure class="line-chart" aria-describedby="sales-stats">
+            <svg viewBox="0 0 240 120" role="img" aria-labelledby="sales-title">
+              <polyline class="line-chart__grid" points="0,100 240,100"></polyline>
+              <polyline class="line-chart__line line-chart__line--accent" points="0,95 40,90 80,70 120,60 160,55 200,35 240,25"></polyline>
+            </svg>
+            <figcaption id="sales-stats" data-i18n="salesCaption">Today $620 · This month $18,400 · Last year $212,000</figcaption>
+          </figure>
+        </article>
+      </div>
+
+      <article class="panel panel--contact" aria-labelledby="contact-title">
+        <h3 id="contact-title" data-i18n="contactTitle">We deliver to</h3>
+        <p data-i18n="contactAreas">Saucés · Alborada · Guayacanes · Tarazana · Brisas del Río</p>
+        <p data-i18n="contactWhatsApp">WhatsApp <a href="https://wa.me/593987654321">+593 958 741 463</a></p>
       </article>
     </section>
   </main>

--- a/main.css
+++ b/main.css
@@ -819,9 +819,11 @@ body::after {
 }
 
 .insights__grid--metrics {
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(260px, 320px));
   width: 100%;
-  justify-items: center;
+  justify-content: center;
+  justify-items: stretch;
+  grid-auto-rows: minmax(260px, auto);
 }
 
 .panel {
@@ -833,6 +835,12 @@ body::after {
   box-shadow: var(--shadow-layered);
   --shape-font-boost: 0px;
   transition: box-shadow var(--transition), filter var(--transition), transform var(--transition);
+}
+
+.panel--metric {
+  max-width: 320px;
+  width: 100%;
+  height: 100%;
 }
 
 .panel--orders {


### PR DESCRIPTION
## Summary
- move the Experience dashboard header and cards below the order details panel
- adjust metric card sizing and grid behavior to match the requested width and height

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd1189c740832bae1b8e691f8fc5de