### PR TITLE
Update delivery contact copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,12 +80,15 @@
 
     <section class="delivery" aria-labelledby="contact-title">
       <article class="panel panel--contact">
-        <h2 id="contact-title" class="panel__delivery-heading">
-          <span data-i18n="contactTitlePrefix">We deliver to:</span>
-          <span data-i18n="contactAreas">Saucés · Alborada · Guayacanes · Tarazana · Brisas del Río</span>
+        <h2
+          id="contact-title"
+          class="panel__delivery-heading"
+          data-i18n="contactDeliveryLine"
+        >
+          Entregamos en: Saucés · Alborada · Guayacanes · Tarazana · Brisas del Río
         </h2>
         <p class="panel__whatsapp">
-          <span data-i18n="contactWhatsApp">WhatsApp</span>
+          <span data-i18n="contactWhatsApp">WhatsApp:</span>
           <a
             href="https://wa.me/593958741463"
             target="_blank"

--- a/main.js
+++ b/main.js
@@ -98,9 +98,8 @@
       summaryIncrease: 'Add one {item}',
       summaryDecrease: 'Remove one {item}',
       inCart: 'In cart: {count}',
-      contactTitlePrefix: 'We deliver to:',
-      contactAreas: 'Saucés · Alborada · Guayacanes · Tarazana · Brisas del Río',
-      contactWhatsApp: 'WhatsApp',
+      contactDeliveryLine: 'We deliver to: Saucés · Alborada · Guayacanes · Tarazana · Brisas del Río',
+      contactWhatsApp: 'WhatsApp:',
       rights: 'All rights reserved.',
       edgeSecurity: 'Edge protected via Cloudflare Zero Trust',
       chatTitle: 'Live chat',
@@ -158,9 +157,8 @@
       summaryIncrease: 'Agregar uno de {item}',
       summaryDecrease: 'Quitar uno de {item}',
       inCart: 'En carrito: {count}',
-      contactTitlePrefix: 'Entregamos en:',
-      contactAreas: 'Saucés · Alborada · Guayacanes · Tarazana · Brisas del Río',
-      contactWhatsApp: 'WhatsApp',
+      contactDeliveryLine: 'Entregamos en: Saucés · Alborada · Guayacanes · Tarazana · Brisas del Río',
+      contactWhatsApp: 'WhatsApp:',
       rights: 'Todos los derechos reservados.',
       edgeSecurity: 'Protección perimetral con Cloudflare Zero Trust',
       chatTitle: 'Chat en vivo',
@@ -773,15 +771,7 @@
         return;
       }
 
-      if (node.querySelector('a') && key === 'contactWhatsApp') {
-        const prefixNode = node.childNodes[0];
-        if (prefixNode) {
-          const prefixText = translation ? `${translation} ` : '';
-          prefixNode.textContent = prefixText;
-        }
-      } else {
-        node.textContent = translation;
-      }
+      node.textContent = translation;
     });
 
     document.querySelectorAll('[data-i18n-placeholder]').forEach((node) => {


### PR DESCRIPTION
## Summary
- show the delivery coverage sentence on a single line and surface the Spanish copy by default
- align the WhatsApp label and i18n strings so both languages include the colon formatting

## Testing
- not run (static content change)

------
https://chatgpt.com/codex/tasks/task_e_68dd63739a7c832ba351d60d7a7f7888