### PR TITLE
Improve landing gallery layout and styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,63 +78,66 @@
         <h2 id="gallery-title">Galería de sabores</h2>
       </div>
       <div class="landing__gallery-track" role="region" aria-labelledby="gallery-title">
->
         <figure class="landing__gallery-item">
-        <img
-          class="gallery__image"
-          src="https://twilight-glade-ca07.distraction.workers.dev/img/cup-of-coffee"
-          width="400"
-          height="250"
-          loading="lazy"
-          decoding="async"
-          referrerpolicy="no-referrer"
-          data-i18n="galleryImage1Alt"
-          data-i18n-attr="alt"
-          data-i18n-skip-text="true"
-          alt="Freshly brewed espresso shot"
-        ></figure>
+          <img
+            class="gallery__image"
+            src="https://twilight-glade-ca07.distraction.workers.dev/img/cup-of-coffee"
+            width="400"
+            height="250"
+            loading="lazy"
+            decoding="async"
+            referrerpolicy="no-referrer"
+            data-i18n="galleryImage1Alt"
+            data-i18n-attr="alt"
+            data-i18n-skip-text="true"
+            alt="Freshly brewed espresso shot"
+          >
+        </figure>
         <figure class="landing__gallery-item">
-        <img
-          class="gallery__image"
-          src="https://twilight-glade-ca07.distraction.workers.dev/img/v2coffee-tortilla-eggs-sausage"
-          width="400"
-          height="250"
-          loading="lazy"
-          decoding="async"
-          referrerpolicy="no-referrer"
-          data-i18n="galleryImage2Alt"
-          data-i18n-attr="alt"
-          data-i18n-skip-text="true"
-          alt="Breakfast tray with coffee, tortilla, eggs, and sausage"
-        ></figure>
+          <img
+            class="gallery__image"
+            src="https://twilight-glade-ca07.distraction.workers.dev/img/v2coffee-tortilla-eggs-sausage"
+            width="400"
+            height="250"
+            loading="lazy"
+            decoding="async"
+            referrerpolicy="no-referrer"
+            data-i18n="galleryImage2Alt"
+            data-i18n-attr="alt"
+            data-i18n-skip-text="true"
+            alt="Breakfast tray with coffee, tortilla, eggs, and sausage"
+          >
+        </figure>
         <figure class="landing__gallery-item">
-        <img
-          class="gallery__image"
-          src="https://twilight-glade-ca07.distraction.workers.dev/img/tortilla"
-          width="400"
-          height="250"
-          loading="lazy"
-          decoding="async"
-          referrerpolicy="no-referrer"
-          data-i18n="galleryImage3Alt"
-          data-i18n-attr="alt"
-          data-i18n-skip-text="true"
-          alt="Golden tortilla on a serving board"
-        ></figure>
+          <img
+            class="gallery__image"
+            src="https://twilight-glade-ca07.distraction.workers.dev/img/tortilla"
+            width="400"
+            height="250"
+            loading="lazy"
+            decoding="async"
+            referrerpolicy="no-referrer"
+            data-i18n="galleryImage3Alt"
+            data-i18n-attr="alt"
+            data-i18n-skip-text="true"
+            alt="Golden tortilla on a serving board"
+          >
+        </figure>
         <figure class="landing__gallery-item">
-        <img
-          class="gallery__image"
-          src="https://twilight-glade-ca07.distraction.workers.dev/img/friedEggs-sausage"
-          width="400"
-          height="250"
-          loading="lazy"
-          decoding="async"
-          referrerpolicy="no-referrer"
-          data-i18n="galleryImage4Alt"
-          data-i18n-attr="alt"
-          data-i18n-skip-text="true"
-          alt="Fried eggs served with sausage"
-        ></figure>
+          <img
+            class="gallery__image"
+            src="https://twilight-glade-ca07.distraction.workers.dev/img/friedEggs-sausage"
+            width="400"
+            height="250"
+            loading="lazy"
+            decoding="async"
+            referrerpolicy="no-referrer"
+            data-i18n="galleryImage4Alt"
+            data-i18n-attr="alt"
+            data-i18n-skip-text="true"
+            alt="Fried eggs served with sausage"
+          >
+        </figure>
       </div>
     </section>
     <section id="contacto" class="landing__about" aria-labelledby="about-title">

--- a/main.css
+++ b/main.css
@@ -608,34 +608,52 @@ body::after {
 
 .landing__gallery-track {
   display: grid;
-  grid-auto-flow: column;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: clamp(1.25rem, 3vw, 2.5rem);
-  overflow-x: auto;
   padding-block: 0.75rem 0.25rem;
-  scroll-snap-type: x mandatory;
-}
-
-.landing__gallery-track::-webkit-scrollbar {
-  height: 8px;
-}
-
-.landing__gallery-track::-webkit-scrollbar-thumb {
-  background: rgba(60, 42, 30, 0.25);
-  border-radius: 999px;
 }
 
 .landing__gallery-item {
-  scroll-snap-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  aspect-ratio: 1 / 1;
   border-radius: 24px;
-  overflow: hidden;
-  box-shadow: 0 18px 40px rgba(60, 42, 30, 0.18);
-  background: rgba(255, 255, 255, 0.85);
+  padding: clamp(0.75rem, 2vw, 1.25rem);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.92), rgba(255, 245, 232, 0.86));
+  box-shadow: 0 18px 40px rgba(60, 42, 30, 0.16);
+  border: 1px solid rgba(60, 42, 30, 0.08);
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.landing__gallery-item:hover,
+.landing__gallery-item:focus-within {
+  transform: translateY(-4px);
+  box-shadow: 0 22px 46px rgba(60, 42, 30, 0.2);
+}
+
+[data-theme="dark"] .landing__gallery-item {
+  background: linear-gradient(145deg, rgba(30, 32, 44, 0.9), rgba(40, 44, 56, 0.82));
+  border-color: rgba(255, 255, 255, 0.06);
+  box-shadow: 0 18px 40px rgba(5, 6, 10, 0.45);
+}
+
+[data-theme="dark"] .landing__gallery-item:hover,
+[data-theme="dark"] .landing__gallery-item:focus-within {
+  box-shadow: 0 22px 46px rgba(5, 6, 10, 0.55);
 }
 
 .landing__gallery-item img {
   display: block;
-  width: min(320px, 70vw);
-  height: auto;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  border-radius: 18px;
+  background-color: #fff7ef;
+}
+
+[data-theme="dark"] .landing__gallery-item img {
+  background-color: rgba(12, 14, 20, 0.88);
 }
 
 .gallery__hint {
@@ -683,21 +701,12 @@ body::after {
 }
 
 .gallery__image {
-  flex: 0 0 auto;
-  width: clamp(240px, 60vw, 320px);
-  height: clamp(13rem, 32vw, 17rem);
-  object-fit: cover;
-  border-radius: calc(var(--radius-md) * 0.8);
-  box-shadow: var(--shadow-soft);
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0));
-  scroll-snap-align: start;
-}
-
-@media (min-width: 768px) {
-  .gallery__image {
-    width: clamp(280px, 35vw, 360px);
-    height: clamp(15rem, 22vw, 18.5rem);
-  }
+  flex: 1 1 auto;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.24), rgba(255, 255, 255, 0));
+  border-radius: 18px;
 }
 
 @media (max-width: 768px) {
@@ -718,13 +727,7 @@ body::after {
   }
 
   .landing__gallery-track {
-    grid-auto-flow: row;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    overflow-x: visible;
-  }
-
-  .landing__gallery-item img {
-    width: 100%;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   }
 }
 


### PR DESCRIPTION
## Summary
- clean up the landing gallery markup so each image renders in a consistent figure wrapper
- restyle the gallery grid to match the reference layout, keeping full images visible in light and dark themes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deaf6ec40c832bb12034645e801073