### PR TITLE
Enhance landing gallery layout for larger product imagery

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,8 +82,8 @@
           <img
             class="gallery__image"
             src="https://twilight-glade-ca07.distraction.workers.dev/img/cup-of-coffee"
-            width="400"
-            height="250"
+            width="640"
+            height="427"
             loading="lazy"
             decoding="async"
             referrerpolicy="no-referrer"
@@ -97,8 +97,8 @@
           <img
             class="gallery__image"
             src="https://twilight-glade-ca07.distraction.workers.dev/img/v2coffee-tortilla-eggs-sausage"
-            width="400"
-            height="250"
+            width="640"
+            height="427"
             loading="lazy"
             decoding="async"
             referrerpolicy="no-referrer"
@@ -112,8 +112,8 @@
           <img
             class="gallery__image"
             src="https://twilight-glade-ca07.distraction.workers.dev/img/tortilla"
-            width="400"
-            height="250"
+            width="640"
+            height="427"
             loading="lazy"
             decoding="async"
             referrerpolicy="no-referrer"
@@ -127,8 +127,8 @@
           <img
             class="gallery__image"
             src="https://twilight-glade-ca07.distraction.workers.dev/img/friedEggs-sausage"
-            width="400"
-            height="250"
+            width="640"
+            height="427"
             loading="lazy"
             decoding="async"
             referrerpolicy="no-referrer"

--- a/main.css
+++ b/main.css
@@ -608,20 +608,20 @@ body::after {
 
 .landing__gallery-track {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: clamp(1.25rem, 3vw, 2.5rem);
-  padding-block: 0.75rem 0.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: clamp(1.5rem, 4vw, 3rem);
+  padding-block: clamp(1rem, 2.5vw, 1.75rem) 0.5rem;
 }
 
 .landing__gallery-item {
   display: flex;
   align-items: center;
   justify-content: center;
-  aspect-ratio: 1 / 1;
-  border-radius: 24px;
-  padding: clamp(0.75rem, 2vw, 1.25rem);
-  background: linear-gradient(145deg, rgba(255, 255, 255, 0.92), rgba(255, 245, 232, 0.86));
-  box-shadow: 0 18px 40px rgba(60, 42, 30, 0.16);
+  aspect-ratio: 4 / 3;
+  border-radius: 28px;
+  padding: clamp(0.5rem, 1.5vw, 1.25rem);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.96), rgba(255, 245, 232, 0.92));
+  box-shadow: 0 26px 52px rgba(60, 42, 30, 0.18);
   border: 1px solid rgba(60, 42, 30, 0.08);
   transition: transform var(--transition), box-shadow var(--transition);
 }
@@ -647,8 +647,8 @@ body::after {
   display: block;
   width: 100%;
   height: 100%;
-  object-fit: contain;
-  border-radius: 18px;
+  object-fit: cover;
+  border-radius: 20px;
   background-color: #fff7ef;
 }
 


### PR DESCRIPTION
## Summary
- enlarge the landing gallery product images to align with the requested presentation
- update gallery grid spacing and card styling for a wider 4:3 layout with stronger visual emphasis

## Testing
- not run (static site changes only)


------
https://chatgpt.com/codex/tasks/task_e_68deb2f4e0b8832b9086008f20800415