### PR TITLE
Reposition landing order CTA and enlarge gallery images

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,10 +64,7 @@
         <p class="landing__eyebrow">Guayaquil · Ecuador</p>
         <h1 id="hero-title" class="landing__headline">Mañanas emblemáticas</h1>
         <h3 class="landing__subheadline">Elige lo que energiza su día.</h3>
-        <div class="landing__cta-group">
-          <a id="orderButton" class="cta" href="order.html">Ordenar ahora</a>
-          <h3 class="landing__promise">Sabores frescos todos los días.</h3>
-        </div>
+        <p class="landing__promise">Sabores frescos todos los días.</p>
       </div>
     </section>
 
@@ -138,6 +135,9 @@
           >
         </figure>
       </div>
+      <div class="landing__gallery-actions">
+        <a id="orderButton" class="cta cta--large" href="order.html">Ordenar ahora</a>
+      </div>
     </section>
     <section id="contacto" class="landing__about" aria-labelledby="about-title">
       <div class="landing__about-card">
@@ -145,6 +145,7 @@
         <h2 class="landing__brand-subheading">Desayunos Bocaditos</h2>
         <h2 class="landing__support">Entregamos en el Norte de Guayaquil: Saucés · Alborada · Guayacanes · Tarazana · Brisas del Río</h2>
         <h3 class="landing__whatsapp">WhatsApp: <a href="https://wa.me/593958741463" target="_blank" rel="noopener noreferrer">+593 958 741 463</a></h3>
+        <a class="cta cta--large landing__cta-secondary" href="order.html">Ordenar ahora</a>
       </div>
     </section>
   </main>

--- a/main.css
+++ b/main.css
@@ -369,8 +369,8 @@ body::after {
 }
 
 .landing__promise {
-  margin: 0;
-  font-size: 1.05rem;
+  margin: 1rem 0 0;
+  font-size: 1.1rem;
   color: rgba(60, 42, 30, 0.7);
 }
 
@@ -551,6 +551,16 @@ body::after {
   transition: transform var(--transition), box-shadow var(--transition), filter var(--transition);
 }
 
+.cta--large {
+  padding: 1.15rem 3.5rem;
+  font-size: 1.2rem;
+  min-width: clamp(240px, 36vw, 360px);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
 .button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
@@ -608,22 +618,24 @@ body::after {
 
 .landing__gallery-track {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: clamp(1.5rem, 4vw, 3rem);
-  padding-block: clamp(1rem, 2.5vw, 1.75rem) 0.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: clamp(2rem, 5vw, 3.5rem);
+  padding-block: clamp(1.25rem, 3vw, 2rem) 0.75rem;
 }
 
 .landing__gallery-item {
   display: flex;
   align-items: center;
   justify-content: center;
-  aspect-ratio: 4 / 3;
-  border-radius: 28px;
-  padding: clamp(0.5rem, 1.5vw, 1.25rem);
+  aspect-ratio: 5 / 4;
+  border-radius: 32px;
+  padding: clamp(0.75rem, 2vw, 1.5rem);
   background: linear-gradient(145deg, rgba(255, 255, 255, 0.96), rgba(255, 245, 232, 0.92));
-  box-shadow: 0 26px 52px rgba(60, 42, 30, 0.18);
+  box-shadow: 0 32px 58px rgba(60, 42, 30, 0.18);
   border: 1px solid rgba(60, 42, 30, 0.08);
   transition: transform var(--transition), box-shadow var(--transition);
+  width: min(100%, 440px);
+  margin-inline: auto;
 }
 
 .landing__gallery-item:hover,
@@ -648,8 +660,14 @@ body::after {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  border-radius: 20px;
+  border-radius: var(--radius-lg);
   background-color: #fff7ef;
+}
+
+.landing__gallery-actions {
+  margin-top: clamp(1.75rem, 4vw, 3rem);
+  display: flex;
+  justify-content: center;
 }
 
 [data-theme="dark"] .landing__gallery-item img {
@@ -809,6 +827,12 @@ body::after {
 
 .landing__whatsapp a {
   color: inherit;
+}
+
+.landing__cta-secondary {
+  justify-self: center;
+  margin-top: clamp(1rem, 3vw, 2.25rem);
+  text-decoration: none;
 }
 
 .landing__secondary {


### PR DESCRIPTION
## Summary
- enlarge the landing gallery cards to better match the sizing used on the order page
- relocate the primary "Ordenar ahora" button beneath the gallery and add a secondary CTA near the WhatsApp contact
- introduce a large CTA style to increase button prominence on the landing page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deb7f48ce0832b85ccaeb1e3af48b5