### PR TITLE
Ensure order product images inherit shared styling

### DIFF
--- a/main.js
+++ b/main.js
@@ -24,6 +24,25 @@
   const accordionTrigger = document.querySelector('.accordion__trigger');
   const accordionContent = document.querySelector('.accordion__content');
   const productCards = Array.from(document.querySelectorAll('.product-card'));
+  const productCardImages = orderSection
+    ? Array.from(orderSection.querySelectorAll('.product-card img'))
+    : [];
+
+  const ensureProductCardImageClass = () => {
+    if (!productCardImages.length) {
+      return;
+    }
+    productCardImages.forEach((image) => {
+      if (!(image instanceof HTMLImageElement)) {
+        return;
+      }
+      if (!image.classList.contains('product-card__image')) {
+        image.classList.add('product-card__image');
+      }
+    });
+  };
+
+  ensureProductCardImageClass();
   const summaryList = document.querySelector('[data-summary-items]');
   const summaryEmpty = document.querySelector('#orderSummaryEmpty');
   const summaryTotals = {

--- a/order.html
+++ b/order.html
@@ -153,6 +153,7 @@
                     src="https://twilight-glade-ca07.distraction.workers.dev/img/cup-of-coffee"
                     alt="Cup of Coffee"
                     loading="lazy"
+                    decoding="async"
                     width="400"
                     height="300"
                     referrerpolicy="no-referrer">
@@ -181,6 +182,7 @@
                     src="https://twilight-glade-ca07.distraction.workers.dev/img/v2coffee-tortilla-eggs-sausage"
                     alt="Coffee Tortilla Egg Sausage"
                     loading="lazy"
+                    decoding="async"
                     width="400"
                     height="300"
                     referrerpolicy="no-referrer">
@@ -209,6 +211,7 @@
                     src="https://twilight-glade-ca07.distraction.workers.dev/img/tortilla"
                     alt="Tortilla"
                     loading="lazy"
+                    decoding="async"
                     width="400"
                     height="300"
                     referrerpolicy="no-referrer">
@@ -237,6 +240,7 @@
                     src="https://twilight-glade-ca07.distraction.workers.dev/img/friedEggs-sausage"
                     alt="Fried Egg, Sausage"
                     loading="lazy"
+                    decoding="async"
                     width="400"
                     height="300"
                     referrerpolicy="no-referrer">
@@ -259,6 +263,7 @@
                     src="https://twilight-glade-ca07.distraction.workers.dev/img/pepsi-cola"
                     alt="Pepsi Cola"
                     loading="lazy"
+                    decoding="async"
                     width="400"
                     height="300"
                     referrerpolicy="no-referrer">
@@ -281,6 +286,7 @@
                     src="https://twilight-glade-ca07.distraction.workers.dev/img/fanta-cola"
                     alt="Fanta Cola"
                     loading="lazy"
+                    decoding="async"
                     width="400"
                     height="300"
                     referrerpolicy="no-referrer">
@@ -303,6 +309,7 @@
                     src="https://twilight-glade-ca07.distraction.workers.dev/img/gallito-cola"
                     alt="Gallito Cola"
                     loading="lazy"
+                    decoding="async"
                     width="400"
                     height="300"
                     referrerpolicy="no-referrer">
@@ -325,6 +332,7 @@
                     src="https://twilight-glade-ca07.distraction.workers.dev/img/inca-cola"
                     alt="Inca Cola"
                     loading="lazy"
+                    decoding="async"
                     width="400"
                     height="300"
                     referrerpolicy="no-referrer">
@@ -347,6 +355,7 @@
                     src="https://twilight-glade-ca07.distraction.workers.dev/img/manzana-cola"
                     alt="Manzana Cola"
                     loading="lazy"
+                    decoding="async"
                     width="400"
                     height="300"
                     referrerpolicy="no-referrer">
@@ -369,6 +378,7 @@
                     src="https://twilight-glade-ca07.distraction.workers.dev/img/seven_up"
                     alt="Seven Up"
                     loading="lazy"
+                    decoding="async"
                     width="400"
                     height="300"
                     referrerpolicy="no-referrer">


### PR DESCRIPTION
## Summary
- add async decoding to order page product images so they render smoothly with the shared `product-card__image` styling
- enforce the `product-card__image` class on order page product photos at runtime to guarantee consistent sizing

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dec5d62588832b9cb54211a498ded5