### PR TITLE
Increase landing navigation link font size

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,11 +51,33 @@
         <p class="landing__brand-tag">Café y Bocaditos</p>
       </div>
     </div>
-    <nav aria-label="Principal" class="landing__nav">
-      <a class="landing__link" href="order.html">Ordenar</a>
-      <a class="landing__link" href="#galeria">Galería</a>
-      <a class="landing__link" href="#contacto">Contacto</a>
-    </nav>
+    <div class="landing__actions">
+      <nav aria-label="Principal" class="landing__nav">
+        <a class="landing__link" href="order.html">Ordenar</a>
+        <a class="landing__link" href="#galeria">Galería</a>
+        <a class="landing__link" href="#contacto">Contacto</a>
+      </nav>
+      <nav aria-label="Preferencias rápidas" class="landing__toggles">
+        <div class="toggle-group" role="group" aria-label="Language selection">
+          <button
+            class="toggle-button"
+            id="languageToggle"
+            type="button"
+            aria-pressed="false"
+            aria-label="Idioma: Español (cambiar a inglés)"
+          >EN</button>
+        </div>
+        <div class="toggle-group" role="group" aria-label="Theme selection">
+          <button
+            class="toggle-button toggle-button--theme"
+            id="themeToggle"
+            type="button"
+            aria-pressed="false"
+            aria-label="Switch to dark theme"
+          >Dark</button>
+        </div>
+      </nav>
+    </div>
   </header>
 
   <main id="mainContent">

--- a/main.css
+++ b/main.css
@@ -240,6 +240,8 @@ body::after {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  flex-wrap: wrap;
+  gap: clamp(0.75rem, 2vw, 1.5rem);
   padding: clamp(1rem, 3vw, 1.75rem) clamp(1.25rem, 4vw, 3.5rem);
   position: sticky;
   top: 0;
@@ -279,11 +281,29 @@ body::after {
   gap: clamp(1rem, 4vw, 2.5rem);
 }
 
+.landing__actions {
+  display: flex;
+  align-items: center;
+  gap: clamp(1rem, 3vw, 2rem);
+  margin-left: auto;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.landing__toggles {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
 .landing__link {
   text-decoration: none;
   color: inherit;
   font-weight: 600;
   position: relative;
+  font-size: clamp(2rem, 4vw, 3.5rem);
 }
 
 .landing__link::after {
@@ -736,7 +756,19 @@ body::after {
     backdrop-filter: none;
   }
 
+  .landing__actions {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1rem;
+  }
+
+  .landing__toggles {
+    justify-content: center;
+  }
+
   .landing__nav {
+    justify-content: center;
     gap: 1.25rem;
   }
 


### PR DESCRIPTION
## Summary
- enlarge the top navigation link typography to improve visibility across viewports by clamping the font size between 2rem and 3.5rem
- add matching language and theme toggles to the landing page header so preferences are available site-wide

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ded0fbc478832ba5d7d5e2c1d1016d