### PR TITLE
Adjust landing page typography for menu and navigation

### DIFF
--- a/main.css
+++ b/main.css
@@ -303,7 +303,7 @@ body::after {
   color: inherit;
   font-weight: 600;
   position: relative;
-  font-size: clamp(2rem, 4vw, 3.5rem);
+  font-size: 1.8rem;
 }
 
 .landing__link::after {
@@ -800,7 +800,7 @@ body::after {
 }
 
 #gallery-title {
-  font-size: 48px;
+  font-size: 2rem;
 }
 
 .section-header p {


### PR DESCRIPTION
## Summary
- set the "Our Menu" section heading to a consistent 2rem size for improved readability
- update the landing navigation links to use a 1.8rem font size per design request

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dee20c28a4832ba2c504a1cf278dd5