### PR TITLE
Restore single language toggle control

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,12 +60,18 @@
       <nav aria-label="Preferencias rápidas" class="landing__toggles">
         <div class="toggle-group" role="group" aria-label="Language selection">
           <button
-            class="toggle-button"
+            class="toggle-button toggle-button--language"
             id="languageToggle"
             type="button"
-            aria-pressed="false"
-            aria-label="Idioma: Español (cambiar a inglés)"
-          >EN</button>
+            role="switch"
+            aria-checked="false"
+            aria-label="Switch to English"
+            data-current-language="es"
+          >
+            <span class="toggle-button__option is-active" data-language-option="es">ES</span>
+            <span class="toggle-button__divider" aria-hidden="true">/</span>
+            <span class="toggle-button__option" data-language-option="en">EN</span>
+          </button>
         </div>
         <div class="toggle-group" role="group" aria-label="Theme selection">
           <button

--- a/main.css
+++ b/main.css
@@ -91,7 +91,7 @@ body.landing {
     linear-gradient(135deg, #fef6e4 0%, #fde2e4 50%, #bee1e6 100%);
   background-attachment: fixed;
   background-size: cover;
-  color: #3c2a1e;
+  color: var(--text-main);
 }
 
 [data-theme="dark"] body {
@@ -251,6 +251,12 @@ body::after {
   border-bottom: 1px solid rgba(255, 255, 255, 0.6);
 }
 
+[data-theme="dark"] .landing__header {
+  background: rgba(12, 13, 18, 0.82);
+  border-bottom: 1px solid rgba(126, 243, 179, 0.25);
+  box-shadow: 0 16px 32px rgba(5, 6, 10, 0.6);
+}
+
 .landing__brand {
   display: inline-flex;
   align-items: center;
@@ -272,7 +278,7 @@ body::after {
 .landing__brand-tag {
   margin: 0;
   font-size: clamp(1rem, 2vw, 1.25rem);
-  color: rgba(60, 42, 30, 0.75);
+  color: var(--text-muted);
 }
 
 .landing__nav {
@@ -359,7 +365,7 @@ body::after {
   text-transform: uppercase;
   font-weight: 600;
   letter-spacing: 0.18em;
-  color: rgba(60, 42, 30, 0.7);
+  color: var(--text-muted);
 }
 
 .landing__headline {
@@ -372,7 +378,7 @@ body::after {
 .landing__hint {
   margin: 0;
   font-weight: 500;
-  color: rgba(60, 42, 30, 0.75);
+  color: var(--text-muted);
   font-size: clamp(1.05rem, 3vw, 1.35rem);
 }
 
@@ -391,7 +397,7 @@ body::after {
 .landing__promise {
   margin: 1rem 0 0;
   font-size: 1.1rem;
-  color: rgba(60, 42, 30, 0.7);
+  color: var(--text-muted);
 }
 
 .topbar__brand {
@@ -500,6 +506,40 @@ body::after {
 
 .toggle-button--theme {
   margin-left: 0.5rem;
+}
+
+.toggle-button--language {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding-right: 1.1rem;
+  padding-left: 1.1rem;
+}
+
+.toggle-button__divider {
+  opacity: 0.65;
+}
+
+.toggle-button__option {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.4rem;
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+  transition: background var(--transition), color var(--transition),
+    box-shadow var(--transition);
+}
+
+.toggle-button__option.is-active {
+  background: var(--accent-strong);
+  color: #ffffff;
+  box-shadow: 0 8px 18px rgba(255, 127, 80, 0.26);
+}
+
+[data-theme="dark"] .toggle-button__option.is-active {
+  color: #0a141f;
+  box-shadow: 0 8px 18px rgba(126, 243, 179, 0.2);
 }
 
 .page {
@@ -838,6 +878,12 @@ body::after {
   gap: 1rem;
 }
 
+[data-theme="dark"] .landing__about-card {
+  background: rgba(20, 22, 32, 0.9);
+  box-shadow: 0 26px 64px rgba(5, 6, 10, 0.6);
+  border: 1px solid rgba(126, 243, 179, 0.2);
+}
+
 .landing__brand-heading {
   margin: 0;
   font-size: clamp(2.2rem, 5vw, 3rem);
@@ -846,7 +892,7 @@ body::after {
 .landing__brand-subheading {
   margin: 0;
   font-weight: 500;
-  color: rgba(60, 42, 30, 0.78);
+  color: var(--text-muted);
 }
 
 .landing__support {
@@ -875,7 +921,7 @@ body::after {
   align-self: start;
   text-decoration: none;
   font-weight: 600;
-  color: #3c2a1e;
+  color: var(--text-main);
   padding: 0.6rem 1.4rem;
   border-radius: 999px;
   border: 1.5px solid rgba(60, 42, 30, 0.4);
@@ -887,6 +933,10 @@ body::after {
   background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
   color: #101319;
   border-color: transparent;
+}
+
+[data-theme="dark"] .landing__secondary {
+  border-color: rgba(126, 243, 179, 0.35);
 }
 
 .order {
@@ -1713,7 +1763,7 @@ body::after {
 .landing__footer {
   padding: 2rem clamp(1.5rem, 6vw, 5.5rem);
   text-align: center;
-  color: rgba(60, 42, 30, 0.7);
+  color: var(--text-muted);
   font-size: 0.95rem;
 }
 

--- a/main.js
+++ b/main.js
@@ -14,6 +14,9 @@
   const drawers = Array.from(document.querySelectorAll('.drawer'));
   const payDrawer = document.querySelector('#payDrawer');
   const languageToggle = document.querySelector('#languageToggle');
+  const languageToggleOptions = languageToggle
+    ? Array.from(languageToggle.querySelectorAll('[data-language-option]'))
+    : [];
   const themeToggle = document.querySelector('#themeToggle');
   const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
   const carousel = document.querySelector('[data-carousel]');
@@ -785,15 +788,26 @@
     html.lang = nextLang;
     localStorage.setItem('marxia-lang', nextLang);
     updateFabMenuSelection();
-    if (languageToggle) {
+    if (languageToggle instanceof HTMLElement) {
       const isSpanish = nextLang === 'es';
-      languageToggle.textContent = isSpanish ? 'EN' : 'ES';
+      languageToggle.setAttribute('data-current-language', nextLang);
+      languageToggle.setAttribute('aria-checked', String(!isSpanish));
       languageToggle.setAttribute(
         'aria-label',
-        isSpanish ? 'Idioma: Español (cambiar a inglés)' : 'Language: English (switch to Spanish)'
+        isSpanish ? 'Switch to English' : 'Cambiar a Español'
       );
-      languageToggle.setAttribute('aria-pressed', String(isSpanish));
     }
+
+    languageToggleOptions.forEach((option) => {
+      if (!(option instanceof HTMLElement)) {
+        return;
+      }
+      const targetLang = option.dataset.languageOption;
+      if (!targetLang) {
+        return;
+      }
+      option.classList.toggle('is-active', targetLang === nextLang);
+    });
 
     const dict = translations[nextLang];
     document.querySelectorAll('[data-i18n]').forEach((node) => {
@@ -1158,14 +1172,19 @@
       return;
     }
 
+    const quickLanguageToggle = target.closest('#languageToggle');
+    if (quickLanguageToggle instanceof HTMLElement) {
+      const optionTarget = target.closest('[data-language-option]');
+      const langChoice = optionTarget?.getAttribute('data-language-option');
+      const nextLanguage = langChoice || (currentLanguage === 'es' ? 'en' : 'es');
+      applyLanguage(nextLanguage);
+      closeMenus();
+      return;
+    }
+
     if (target === themeToggle) {
       const nextTheme = html.dataset.theme === 'dark' ? 'light' : 'dark';
       applyTheme(nextTheme);
-    }
-
-    if (target === languageToggle) {
-      const nextLang = html.lang === 'es' ? 'en' : 'es';
-      applyLanguage(nextLang);
     }
 
     const closeButton = target.closest('[data-close-drawer]');


### PR DESCRIPTION
## Summary
- replace the dual language buttons with a single switch-style control that highlights the active locale
- update CSS to style the combined language toggle with clear active states in both light and dark themes
- adjust language scripting to drive the unified control, including aria metadata and click handling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dee61cd68c832ba6a06e3825faf6dd