### PR TITLE
Enhance order carousel legibility

### DIFF
--- a/main.css
+++ b/main.css
@@ -1027,8 +1027,8 @@ body::after {
   transform: translateY(-50%);
   border: none;
   border-radius: 999px;
-  width: 48px;
-  height: 48px;
+  width: 64px;
+  height: 64px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1069,7 +1069,7 @@ body::after {
 }
 
 .product-carousel__control span {
-  font-size: 1.6rem;
+  font-size: 2.15rem;
   line-height: 1;
 }
 
@@ -1203,7 +1203,7 @@ body::after {
 .product-card__meta {
   margin: 0;
   color: var(--text-muted);
-  font-size: calc(0.95rem + (var(--shape-font-boost) * 0.35));
+  font-size: calc(1.1rem + (var(--shape-font-boost) * 0.45));
   transition: font-size var(--transition);
 }
 
@@ -1221,7 +1221,7 @@ body::after {
 
 .product-card__price {
   font-weight: 700;
-  font-size: calc(1.05rem + (var(--shape-font-boost) * 0.4));
+  font-size: calc(1.25rem + (var(--shape-font-boost) * 0.55));
   text-align: center;
   transition: font-size var(--transition);
 }


### PR DESCRIPTION
## Summary
- enlarge the order page carousel controls for better visibility and tap targets
- increase product description and price typography to improve readability

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68df30f0543c832b99dc820ac30cc883