### PR TITLE
Adjust hero typography and simplify contact layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,13 +169,11 @@
       </div>
     </section>
     <section id="contacto" class="landing__about" aria-labelledby="about-title">
-      <div class="landing__about-card">
-        <h1 id="about-title" class="landing__brand-heading">Marxia Café y Bocaditos</h1>
-        <h2 class="landing__brand-subheading">Desayunos Bocaditos</h2>
-        <h2 class="landing__support">Entregamos en el Norte de Guayaquil: Saucés · Alborada · Guayacanes · Tarazana · Brisas del Río</h2>
-        <h3 class="landing__whatsapp">WhatsApp: <a href="https://wa.me/593958741463" target="_blank" rel="noopener noreferrer">+593 958 741 463</a></h3>
-        <a class="cta cta--large landing__cta-secondary" href="order.html">Ordenar ahora</a>
-      </div>
+      <h1 id="about-title" class="landing__brand-heading">Marxia Café y Bocaditos</h1>
+      <h2 class="landing__brand-subheading">Desayunos Bocaditos</h2>
+      <h2 class="landing__support">Entregamos en el Norte de Guayaquil: Saucés · Alborada · Guayacanes · Tarazana · Brisas del Río</h2>
+      <h3 class="landing__whatsapp">WhatsApp: <a href="https://wa.me/593958741463" target="_blank" rel="noopener noreferrer">+593 958 741 463</a></h3>
+      <a class="cta cta--large landing__cta-secondary" href="order.html">Ordenar ahora</a>
     </section>
   </main>
 

--- a/main.css
+++ b/main.css
@@ -366,11 +366,12 @@ body::after {
   font-weight: 600;
   letter-spacing: 0.18em;
   color: var(--text-muted);
+  font-size: 1rem;
 }
 
 .landing__headline {
   margin: 0;
-  font-size: clamp(2.8rem, 7vw, 4rem);
+  font-size: 1.5rem;
   line-height: 1.05;
 }
 
@@ -379,7 +380,7 @@ body::after {
   margin: 0;
   font-weight: 500;
   color: var(--text-muted);
-  font-size: clamp(1.05rem, 3vw, 1.35rem);
+  font-size: 1.2rem;
 }
 
 .landing__hint {
@@ -396,7 +397,7 @@ body::after {
 
 .landing__promise {
   margin: 1rem 0 0;
-  font-size: 1.1rem;
+  font-size: 1.2rem;
   color: var(--text-muted);
 }
 
@@ -864,24 +865,10 @@ body::after {
 
 .landing__about {
   padding: clamp(3rem, 8vw, 6.5rem) clamp(1.5rem, 6vw, 5.5rem);
-  display: flex;
-  justify-content: center;
-}
-
-.landing__about-card {
-  max-width: 680px;
-  background: rgba(255, 255, 255, 0.88);
-  border-radius: 32px;
-  padding: clamp(2rem, 6vw, 4rem);
-  box-shadow: 0 30px 70px rgba(60, 42, 30, 0.16);
   display: grid;
+  justify-items: center;
   gap: 1rem;
-}
-
-[data-theme="dark"] .landing__about-card {
-  background: rgba(20, 22, 32, 0.9);
-  box-shadow: 0 26px 64px rgba(5, 6, 10, 0.6);
-  border: 1px solid rgba(126, 243, 179, 0.2);
+  text-align: center;
 }
 
 .landing__brand-heading {


### PR DESCRIPTION
## Summary
- set fixed typography scale for hero eyebrow, headline, subheadline, and promise text
- remove the about card wrapper and re-center the contact details for a lighter layout

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df369298b4832b97cf449e98fe6cc2