### PR TITLE
Increase Our Menu section heading size

### DIFF
--- a/main.css
+++ b/main.css
@@ -840,7 +840,7 @@ body::after {
 }
 
 #gallery-title {
-  font-size: 2rem;
+  font-size: clamp(2.5rem, 6vw, 3.5rem);
 }
 
 .section-header p {


### PR DESCRIPTION
## Summary
- increase the Our Menu gallery heading size to scale up to 56px using a responsive clamp

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df35cb478c832bb8673178feda47fe