### PR TITLE
Add bilingual language support across public pages

### DIFF
--- a/consent.html
+++ b/consent.html
@@ -3,34 +3,61 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Gestión de Consentimiento | Marxia Café y Bocaditos</title>
+    <title data-i18n="consentMetaTitle">Gestión de Consentimiento | Marxia Café y Bocaditos</title>
     <meta
       name="description"
       content="Resumen de consentimiento, cookies y opciones de privacidad para Marxia Café y Bocaditos."
+      data-i18n="consentMetaDescription"
+      data-i18n-attr="content"
     >
     <link rel="canonical" href="https://marxia.ec/consentimiento">
     <link rel="stylesheet" href="main.css">
   </head>
   <body>
-    <a class="skip-link" href="#main">Saltar al contenido principal</a>
+    <a class="skip-link" href="#main" data-i18n="skipToContent">Saltar al contenido principal</a>
     <header class="legal__header" role="banner">
       <div class="legal__branding">
-        <h1>Gestión de consentimiento</h1>
-        <p>Transparencia en cómo recopilamos, usamos y protegemos tus datos.</p>
+        <h1 data-i18n="consentHeading">Gestión de consentimiento</h1>
+        <p data-i18n="consentTagline">Transparencia en cómo recopilamos, usamos y protegemos tus datos.</p>
       </div>
       <nav aria-label="Legal">
         <ul class="legal__nav-list">
-          <li><a href="index.html">Inicio</a></li>
-          <li><a href="order.html">Ordenar</a></li>
-          <li><a href="terms.html">Términos y Condiciones</a></li>
+          <li><a href="index.html" data-i18n="navHome">Inicio</a></li>
+          <li><a href="order.html" data-i18n="navOrder">Ordenar</a></li>
+          <li><a href="terms.html" data-i18n="navTerms">Términos y Condiciones</a></li>
         </ul>
       </nav>
+      <div class="legal__preferences">
+        <nav aria-label="Preferencias rápidas" class="landing__toggles" data-i18n="quickPreferences" data-i18n-attr="aria-label" data-i18n-skip-text="true">
+          <div class="toggle-group" role="group" aria-label="Language selection" data-i18n="languageSelection" data-i18n-attr="aria-label" data-i18n-skip-text="true">
+            <button
+              class="toggle-button toggle-button--language"
+              id="languageToggle"
+              type="button"
+              role="switch"
+              aria-checked="false"
+              aria-label="Switch to English"
+              data-current-language="es"
+            >ES</button>
+          </div>
+
+          <div class="toggle-group" role="group" aria-label="Theme selection" data-i18n="themeSelection" data-i18n-attr="aria-label" data-i18n-skip-text="true">
+            <button
+              class="toggle-button toggle-button--theme"
+              id="themeToggle"
+              type="button"
+              aria-pressed="false"
+            aria-label="Cambiar a tema oscuro"
+            >Oscuro</button>
+          </div>
+        </nav>
+      </div>
     </header>
 
     <main id="main" class="legal__main" tabindex="-1">
       <section class="legal__section" aria-labelledby="overview-title">
-        <h2 id="overview-title">Resumen general</h2>
-        <p>
+        <h2 id="overview-title" data-i18n="consentOverviewTitle">Resumen general</h2>
+        <p data-i18n="consentOverviewBody">
           Marxia Café y Bocaditos opera con un enfoque de privacidad por diseño y por defecto. Procesamos la
           información personal únicamente con fundamentos legales claros, registramos el consentimiento y ofrecemos
           mecanismos sencillos para que puedas ajustar tus preferencias en cualquier momento.
@@ -38,94 +65,94 @@
       </section>
 
       <section class="legal__section" aria-labelledby="data-we-collect">
-        <h2 id="data-we-collect">Datos que recopilamos</h2>
-        <p>La información que podemos procesar se clasifica de la siguiente manera:</p>
+        <h2 id="data-we-collect" data-i18n="consentDataTitle">Datos que recopilamos</h2>
+        <p data-i18n="consentDataIntro">La información que podemos procesar se clasifica de la siguiente manera:</p>
         <ul>
-          <li><strong>Datos esenciales:</strong> elementos necesarios para brindar el servicio solicitado, como idioma seleccionado, artículos en el carrito y opciones de entrega.</li>
-          <li><strong>Datos de contacto:</strong> nombre, correo electrónico o teléfono cuando decides interactuar mediante formularios o canales de mensajería.</li>
-          <li><strong>Métricas de experiencia:</strong> información pseudonimizada sobre el uso del sitio para mejorar accesibilidad, rendimiento y seguridad.</li>
+          <li data-i18n="consentDataEssential" data-i18n-html="true"><strong>Datos esenciales:</strong> elementos necesarios para brindar el servicio solicitado, como idioma seleccionado, artículos en el carrito y opciones de entrega.</li>
+          <li data-i18n="consentDataContact" data-i18n-html="true"><strong>Datos de contacto:</strong> nombre, correo electrónico o teléfono cuando decides interactuar mediante formularios o canales de mensajería.</li>
+          <li data-i18n="consentDataMetrics" data-i18n-html="true"><strong>Métricas de experiencia:</strong> información pseudonimizada sobre el uso del sitio para mejorar accesibilidad, rendimiento y seguridad.</li>
         </ul>
       </section>
 
       <section class="legal__section" aria-labelledby="legal-basis">
-        <h2 id="legal-basis">Base legal para el procesamiento</h2>
-        <p>Procesamos tus datos personales bajo los siguientes fundamentos:</p>
+        <h2 id="legal-basis" data-i18n="consentLegalTitle">Base legal para el procesamiento</h2>
+        <p data-i18n="consentLegalIntro">Procesamos tus datos personales bajo los siguientes fundamentos:</p>
         <ul>
-          <li><strong>Consentimiento explícito:</strong> requerido para el uso de cookies no esenciales, marketing personalizado y comunicaciones opcionales.</li>
-          <li><strong>Ejecución de un contrato:</strong> cuando solicitas productos o servicios y necesitamos tus datos para completar la entrega.</li>
-          <li><strong>Interés legítimo:</strong> para prevenir fraude, proteger la infraestructura y mejorar la accesibilidad del sitio, siempre respetando tus derechos.</li>
+          <li data-i18n="consentLegalConsent" data-i18n-html="true"><strong>Consentimiento explícito:</strong> requerido para el uso de cookies no esenciales, marketing personalizado y comunicaciones opcionales.</li>
+          <li data-i18n="consentLegalContract" data-i18n-html="true"><strong>Ejecución de un contrato:</strong> cuando solicitas productos o servicios y necesitamos tus datos para completar la entrega.</li>
+          <li data-i18n="consentLegalInterest" data-i18n-html="true"><strong>Interés legítimo:</strong> para prevenir fraude, proteger la infraestructura y mejorar la accesibilidad del sitio, siempre respetando tus derechos.</li>
         </ul>
       </section>
 
       <section class="legal__section" aria-labelledby="cookie-categories">
-        <h2 id="cookie-categories">Categorías de cookies y tecnologías similares</h2>
+        <h2 id="cookie-categories" data-i18n="consentCookiesTitle">Categorías de cookies y tecnologías similares</h2>
         <table class="legal__table">
-          <caption>Uso responsable de cookies</caption>
+          <caption data-i18n="consentCookiesCaption">Uso responsable de cookies</caption>
           <thead>
             <tr>
-              <th scope="col">Categoría</th>
-              <th scope="col">Propósito</th>
-              <th scope="col">Duración</th>
-              <th scope="col">Base legal</th>
+              <th scope="col" data-i18n="consentCookiesColumnCategory">Categoría</th>
+              <th scope="col" data-i18n="consentCookiesColumnPurpose">Propósito</th>
+              <th scope="col" data-i18n="consentCookiesColumnDuration">Duración</th>
+              <th scope="col" data-i18n="consentCookiesColumnLegal">Base legal</th>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <th scope="row">Esenciales</th>
-              <td>Mantener el inicio de sesión, recordar el idioma o preferencias de accesibilidad, asegurar la integridad de pagos.</td>
-              <td>Sesión o hasta 12 meses</td>
-              <td>Ejecución de contrato / Interés legítimo</td>
+              <th scope="row" data-i18n="consentCookiesEssential">Esenciales</th>
+              <td data-i18n="consentCookiesEssentialPurpose">Mantener el inicio de sesión, recordar el idioma o preferencias de accesibilidad, asegurar la integridad de pagos.</td>
+              <td data-i18n="consentCookiesEssentialDuration">Sesión o hasta 12 meses</td>
+              <td data-i18n="consentCookiesEssentialLegal">Ejecución de contrato / Interés legítimo</td>
             </tr>
             <tr>
-              <th scope="row">Analíticas</th>
-              <td>Medir visitas, detectar errores y optimizar la experiencia.</td>
-              <td>30 minutos a 24 meses</td>
-              <td>Consentimiento</td>
+              <th scope="row" data-i18n="consentCookiesAnalytics">Analíticas</th>
+              <td data-i18n="consentCookiesAnalyticsPurpose">Medir visitas, detectar errores y optimizar la experiencia.</td>
+              <td data-i18n="consentCookiesAnalyticsDuration">30 minutos a 24 meses</td>
+              <td data-i18n="consentCookiesAnalyticsLegal">Consentimiento</td>
             </tr>
             <tr>
-              <th scope="row">Marketing</th>
-              <td>Enviar promociones relevantes o recordatorios opt-in.</td>
-              <td>Hasta revocación</td>
-              <td>Consentimiento</td>
+              <th scope="row" data-i18n="consentCookiesMarketing">Marketing</th>
+              <td data-i18n="consentCookiesMarketingPurpose">Enviar promociones relevantes o recordatorios opt-in.</td>
+              <td data-i18n="consentCookiesMarketingDuration">Hasta revocación</td>
+              <td data-i18n="consentCookiesMarketingLegal">Consentimiento</td>
             </tr>
           </tbody>
         </table>
-        <p>
+        <p data-i18n="consentCookiesNote">
           Las cookies analíticas y de marketing se encuentran desactivadas por defecto. Podrás activarlas o desactivarlas
           desde el Centro de Preferencias de Consentimiento visible en la parte inferior del sitio.
         </p>
       </section>
 
       <section class="legal__section" aria-labelledby="consent-center">
-        <h2 id="consent-center">Centro de preferencias dinámico</h2>
-        <p>
+        <h2 id="consent-center" data-i18n="consentCenterTitle">Centro de preferencias dinámico</h2>
+        <p data-i18n="consentCenterIntro">
           Controla qué categorías opcionales autorizas en tiempo real. Los cambios se guardan al instante y aplican al resto
           del sitio, respetando el principio de privacidad por defecto.
         </p>
 
         <div class="consent-center" data-consent-center role="region" aria-live="polite">
           <div class="consent-center__actions">
-            <button type="button" class="consent-center__button consent-center__button--primary" data-consent-accept>
+            <button type="button" class="consent-center__button consent-center__button--primary" data-consent-accept data-i18n="consentAcceptAll">
               Permitir todo
             </button>
-            <button type="button" class="consent-center__button" data-consent-reject>
+            <button type="button" class="consent-center__button" data-consent-reject data-i18n="consentRejectAll">
               Rechazar opcionales
             </button>
           </div>
-          <p class="consent-center__status" data-consent-status role="status">
+          <p class="consent-center__status" data-consent-status role="status" data-i18n="consentStatusIdle">
             Ajusta tus preferencias y guarda los cambios para personalizar tu experiencia.
           </p>
-          <p class="consent-center__timestamp">
+          <p class="consent-center__timestamp" data-i18n="consentTimestampLabel">
             Última actualización: <time data-consent-timestamp hidden></time>
           </p>
 
           <ul class="consent-grid" role="list">
             <li class="consent-card consent-card--locked" data-consent-card>
               <div class="consent-card__header">
-                <h3>Esenciales</h3>
-                <span class="consent-badge" aria-label="Necesario">Necesario</span>
+                <h3 data-i18n="consentEssentialCard">Esenciales</h3>
+                <span class="consent-badge" aria-label="Necesario" data-i18n="consentBadgeRequired" data-i18n-attr="aria-label">Necesario</span>
               </div>
-              <p>
+              <p data-i18n="consentEssentialCopy">
                 Garantizan que la plataforma funcione de forma segura: inicio de sesión, idioma, accesibilidad y
                 mantenimiento de pedidos.
               </p>
@@ -138,21 +165,23 @@
                     role="switch"
                     aria-checked="true"
                     aria-label="Las cookies esenciales siempre están activas"
+                    data-i18n="consentEssentialAria"
+                    data-i18n-attr="aria-label"
                   >
                   <span class="consent-switch__track" aria-hidden="true">
                     <span class="consent-switch__thumb"></span>
                   </span>
-                  <span class="consent-switch__state" aria-hidden="true">Activo</span>
+                  <span class="consent-switch__state" aria-hidden="true" data-i18n="consentSwitchActive">Activo</span>
                 </label>
               </div>
             </li>
 
             <li class="consent-card" data-consent-card>
               <div class="consent-card__header">
-                <h3>Analíticas</h3>
-                <span class="consent-badge consent-badge--optional">Opcional</span>
+                <h3 data-i18n="consentAnalyticsCard">Analíticas</h3>
+                <span class="consent-badge consent-badge--optional" data-i18n="consentBadgeOptional">Opcional</span>
               </div>
-              <p>
+              <p data-i18n="consentAnalyticsCopy">
                 Nos ayudan a medir el rendimiento, detectar incidencias y mejorar la experiencia sin identificarte
                 directamente.
               </p>
@@ -164,21 +193,23 @@
                     role="switch"
                     aria-checked="false"
                     aria-label="Activar o desactivar cookies analíticas"
+                    data-i18n="consentAnalyticsAria"
+                    data-i18n-attr="aria-label"
                   >
                   <span class="consent-switch__track" aria-hidden="true">
                     <span class="consent-switch__thumb"></span>
                   </span>
-                  <span class="consent-switch__state" aria-hidden="true">Activo</span>
+                  <span class="consent-switch__state" aria-hidden="true" data-i18n="consentSwitchActive">Activo</span>
                 </label>
               </div>
             </li>
 
             <li class="consent-card" data-consent-card>
               <div class="consent-card__header">
-                <h3>Marketing</h3>
-                <span class="consent-badge consent-badge--optional">Opcional</span>
+                <h3 data-i18n="consentMarketingCard">Marketing</h3>
+                <span class="consent-badge consent-badge--optional" data-i18n="consentBadgeOptional">Opcional</span>
               </div>
-              <p>
+              <p data-i18n="consentMarketingCopy">
                 Personalizan comunicaciones y campañas que podrían interesarte según tus gustos y pedidos previos.
               </p>
               <div class="consent-card__control">
@@ -189,11 +220,13 @@
                     role="switch"
                     aria-checked="false"
                     aria-label="Activar o desactivar comunicaciones de marketing"
+                    data-i18n="consentMarketingAria"
+                    data-i18n-attr="aria-label"
                   >
                   <span class="consent-switch__track" aria-hidden="true">
                     <span class="consent-switch__thumb"></span>
                   </span>
-                  <span class="consent-switch__state" aria-hidden="true">Activo</span>
+                  <span class="consent-switch__state" aria-hidden="true" data-i18n="consentSwitchActive">Activo</span>
                 </label>
               </div>
             </li>
@@ -202,34 +235,34 @@
       </section>
 
       <section class="legal__section" aria-labelledby="manage-preferences">
-        <h2 id="manage-preferences">Gestiona tus preferencias</h2>
+        <h2 id="manage-preferences" data-i18n="consentManageTitle">Gestiona tus preferencias</h2>
         <ol>
-          <li>Haz clic en el botón "Preferencias de privacidad" en el pie de página.</li>
-          <li>Selecciona cada categoría para ver su descripción y activar o desactivar según tus necesidades.</li>
-          <li>Guarda los cambios. Tus ajustes se sincronizarán en todos los dispositivos donde utilices la misma cuenta.</li>
+          <li data-i18n="consentManageStepOne">Haz clic en el botón "Preferencias de privacidad" en el pie de página.</li>
+          <li data-i18n="consentManageStepTwo">Selecciona cada categoría para ver su descripción y activar o desactivar según tus necesidades.</li>
+          <li data-i18n="consentManageStepThree">Guarda los cambios. Tus ajustes se sincronizarán en todos los dispositivos donde utilices la misma cuenta.</li>
         </ol>
-        <p>Siempre podrás retirar tu consentimiento sin afectar la legalidad del procesamiento previo a la revocación.</p>
+        <p data-i18n="consentManageNote">Siempre podrás retirar tu consentimiento sin afectar la legalidad del procesamiento previo a la revocación.</p>
       </section>
 
       <section class="legal__section" aria-labelledby="data-rights">
-        <h2 id="data-rights">Tus derechos de privacidad</h2>
-        <p>Dependiendo de tu jurisdicción, puedes ejercer los siguientes derechos:</p>
+        <h2 id="data-rights" data-i18n="consentRightsTitle">Tus derechos de privacidad</h2>
+        <p data-i18n="consentRightsIntro">Dependiendo de tu jurisdicción, puedes ejercer los siguientes derechos:</p>
         <ul>
-          <li>Acceso, rectificación y actualización de tu información personal.</li>
-          <li>Eliminación o anonimización de datos cuando ya no sean necesarios.</li>
-          <li>Portabilidad de datos en un formato estructurado.</li>
-          <li>Oposición o restricción al procesamiento basado en intereses legítimos.</li>
-          <li>Presentar quejas ante la autoridad de control competente.</li>
+          <li data-i18n="consentRightsAccess">Acceso, rectificación y actualización de tu información personal.</li>
+          <li data-i18n="consentRightsDeletion">Eliminación o anonimización de datos cuando ya no sean necesarios.</li>
+          <li data-i18n="consentRightsPortability">Portabilidad de datos en un formato estructurado.</li>
+          <li data-i18n="consentRightsObjection">Oposición o restricción al procesamiento basado en intereses legítimos.</li>
+          <li data-i18n="consentRightsComplaint">Presentar quejas ante la autoridad de control competente.</li>
         </ul>
-        <p>
+        <p data-i18n="consentRightsContact" data-i18n-html="true">
           Para ejercer cualquiera de estos derechos, escríbenos a
           <a href="mailto:privacidad@marxia.ec">privacidad@marxia.ec</a> o envíanos un mensaje vía WhatsApp.
         </p>
       </section>
 
       <section class="legal__section" aria-labelledby="retention">
-        <h2 id="retention">Conservación y seguridad de los datos</h2>
-        <p>
+        <h2 id="retention" data-i18n="consentRetentionTitle">Conservación y seguridad de los datos</h2>
+        <p data-i18n="consentRetentionBody">
           Conservamos los datos personales únicamente durante el tiempo necesario para cumplir con los fines descritos o según
           lo requiera la ley aplicable. Implementamos cifrado, controles de acceso y monitoreo continuo conforme a NIST CSF,
           CISA Cyber Essentials y PCI DSS 4.0 para proteger tu información contra accesos no autorizados, pérdida o divulgación.
@@ -237,8 +270,8 @@
       </section>
 
       <section class="legal__section" aria-labelledby="updates">
-        <h2 id="updates">Actualizaciones</h2>
-        <p>
+        <h2 id="updates" data-i18n="consentUpdatesTitle">Actualizaciones</h2>
+        <p data-i18n="consentUpdatesBody" data-i18n-html="true">
           Revisamos esta política de consentimiento de manera periódica. Notificaremos cambios sustanciales mediante banners en
           el sitio y fecha de actualización visible. Última actualización: <time datetime="2024-06-01">1 de junio de 2024</time>.
         </p>
@@ -246,16 +279,20 @@
     </main>
 
     <footer class="legal__footer">
-      <p>&copy; <span id="legalYear"></span> Marxia Café y Bocaditos. Todos los derechos reservados.</p>
+      <p>&copy; <span id="legalYear"></span> <span data-i18n="consentFooterRights">Marxia Café y Bocaditos. Todos los derechos reservados.</span></p>
       <p>
-        Consulta también nuestros <a href="terms.html">Términos y Condiciones</a> y la
-        <a href="index.html#consent">configuración de preferencias</a> para administrar cookies.
+        <span data-i18n="consentFooterLinksPrefix">Consulta también nuestros</span>
+        <a href="terms.html" data-i18n="consentFooterTerms">Términos y Condiciones</a>
+        <span data-i18n="consentFooterAnd">y la</span>
+        <a href="index.html#consent" data-i18n="consentFooterPreferences">configuración de preferencias</a>
+        <span data-i18n="consentFooterSuffix">para administrar cookies.</span>
       </p>
     </footer>
 
     <script>
       document.getElementById('legalYear').textContent = new Date().getFullYear();
     </script>
+    <script src="main.js" defer></script>
     <script type="module" src="consent-page.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -43,24 +43,24 @@
   </script>
 </head>
 <body class="landing">
-  <a class="skip-link" href="#mainContent">Saltar al contenido</a>
+  <a class="skip-link" href="#mainContent" data-i18n="skipToContent">Saltar al contenido</a>
   <div class="landing__background-illustration" aria-hidden="true"></div>
   <header class="landing__header" role="banner">
     <div class="landing__brand">
       <img src="https://twilight-glade-ca07.distraction.workers.dev/img/cup-of-coffee" alt="Taza de café" loading="lazy" width="64" height="64">
       <div>
-        <p class="landing__brand-name">Marxia</p>
-        <p class="landing__brand-tag">Café y Bocaditos</p>
+        <p class="landing__brand-name" data-i18n="brandName">Marxia</p>
+        <p class="landing__brand-tag" data-i18n="brandTagline">Café y Bocaditos</p>
       </div>
     </div>
     <div class="landing__actions">
       <nav aria-label="Principal" class="landing__nav">
-        <a class="landing__link" href="order.html">Ordena</a>
-        <a class="landing__link" href="#galeria">Galería</a>
-        <a class="landing__link" href="#contacto">Contacto</a>
+        <a class="landing__link" href="order.html" data-i18n="navOrder">Ordena</a>
+        <a class="landing__link" href="#galeria" data-i18n="navGallery">Galería</a>
+        <a class="landing__link" href="#contacto" data-i18n="navContact">Contacto</a>
       </nav>
-      <nav aria-label="Preferencias rápidas" class="landing__toggles">
-        <div class="toggle-group" role="group" aria-label="Language selection">
+      <nav aria-label="Preferencias rápidas" class="landing__toggles" data-i18n="quickPreferences" data-i18n-attr="aria-label" data-i18n-skip-text="true">
+        <div class="toggle-group" role="group" aria-label="Language selection" data-i18n="languageSelection" data-i18n-attr="aria-label" data-i18n-skip-text="true">
           <button
             class="toggle-button toggle-button--language"
             id="languageToggle"
@@ -71,15 +71,15 @@
             data-current-language="es"
           >ES</button>
         </div>
-      
-        <div class="toggle-group" role="group" aria-label="Theme selection">
+
+        <div class="toggle-group" role="group" aria-label="Theme selection" data-i18n="themeSelection" data-i18n-attr="aria-label" data-i18n-skip-text="true">
           <button
             class="toggle-button toggle-button--theme"
             id="themeToggle"
             type="button"
             aria-pressed="false"
-            aria-label="Switch to dark theme"
-          >Dark</button>
+            aria-label="Cambiar a tema oscuro"
+          >Oscuro</button>
         </div>
       </nav>
     </div>
@@ -88,17 +88,17 @@
   <main id="mainContent">
     <section class="landing__hero" aria-labelledby="hero-title">
       <div class="landing__hero-content">
-        <p class="landing__eyebrow">Guayaquil · Ecuador</p>
-        <h1 id="hero-title" class="landing__headline">Mañanas emblemáticas</h1>
-        <h3 class="landing__subheadline">Elige lo que energiza su día.</h3>
-        <p class="landing__promise">Sabores frescos todos los días.</p>
+        <p class="landing__eyebrow" data-i18n="heroEyebrow">Guayaquil · Ecuador</p>
+        <h1 id="hero-title" class="landing__headline" data-i18n="heroTitle">Mañanas emblemáticas</h1>
+        <h3 class="landing__subheadline" data-i18n="heroSubtitle">Elige lo que energiza su día.</h3>
+        <p class="landing__promise" data-i18n="promise">Sabores frescos todos los días.</p>
       </div>
     </section>
 
     <section id="galeria" class="landing__gallery" aria-labelledby="gallery-title">
       
       <div class="section-header">
-        <h1 id="gallery-title">Our Menu</h1>
+        <h1 id="gallery-title" data-i18n="galleryTitle">Our Menu</h1>
       </div>
       <div class="landing__gallery-track" role="region" aria-labelledby="gallery-title">
         <figure class="landing__gallery-item">
@@ -163,25 +163,28 @@
         </figure>
       </div>
       <div class="landing__gallery-actions">
-        <a id="orderButton" class="cta cta--large" href="order.html">Ordena ahora</a>
+        <a id="orderButton" class="cta cta--large" href="order.html" data-i18n="orderNow">Ordena ahora</a>
       </div>
     </section>
     <section id="contacto" class="landing__about" aria-labelledby="about-title">
-      <h1 id="about-title" class="landing__brand-heading">Marxia Café y Bocaditos</h1>
-      <h2 class="landing__brand-subheading">Desayunos Bocaditos</h2>
-      <h2 class="landing__support">Entregamos en el Norte de Guayaquil: Saucés · Alborada · Guayacanes · Tarazana · Brisas del Río</h2>
-      <h3 class="landing__whatsapp">WhatsApp: <a href="https://wa.me/593958741463" target="_blank" rel="noopener noreferrer">+593 958 741 463</a></h3>
-      <a class="cta cta--large landing__cta-secondary" href="order.html">Ordena ahora</a>
+      <h1 id="about-title" class="landing__brand-heading" data-i18n="brandTitle">Marxia Café y Bocaditos</h1>
+      <h2 class="landing__brand-subheading" data-i18n="brandSubheading">Desayunos Bocaditos</h2>
+      <h2 class="landing__support" data-i18n="deliveryCoverage">Entregamos en el Norte de Guayaquil: Saucés · Alborada · Guayacanes · Tarazana · Brisas del Río</h2>
+      <h3 class="landing__whatsapp">
+        <span data-i18n="contactWhatsAppLabel">WhatsApp:</span>
+        <a href="https://wa.me/593958741463" target="_blank" rel="noopener noreferrer">+593 958 741 463</a>
+      </h3>
+      <a class="cta cta--large landing__cta-secondary" href="order.html" data-i18n="orderNow">Ordena ahora</a>
     </section>
   </main>
 
   <footer class="landing__footer">
-    <p>&copy; <span id="copyrightYear"></span> Marxia Café y Bocaditos. Seguridad reforzada con buenas prácticas PCI DSS, NIST CSF y CISA.</p>
-    <nav aria-label="Información legal" class="landing__legal-links">
+    <p>&copy; <span id="copyrightYear"></span> <span data-i18n="landingFooterSecurity">Marxia Café y Bocaditos. Seguridad reforzada con buenas prácticas PCI DSS, NIST CSF y CISA.</span></p>
+    <nav aria-label="Información legal" class="landing__legal-links" data-i18n="legalInfo" data-i18n-attr="aria-label" data-i18n-skip-text="true">
       <ul>
-        <li><a href="consent.html">Gestión de consentimiento</a></li>
-        <li><a href="terms.html">Términos y Condiciones</a></li>
-        <li><a href="mailto:legal@marxia.ec">Contacto legal</a></li>
+        <li><a href="consent.html" data-i18n="footerConsentLink">Gestión de consentimiento</a></li>
+        <li><a href="terms.html" data-i18n="footerTermsLink">Términos y Condiciones</a></li>
+        <li><a href="mailto:legal@marxia.ec" data-i18n="footerLegalContact">Contacto legal</a></li>
       </ul>
     </nav>
   </footer>

--- a/main.js
+++ b/main.js
@@ -31,10 +31,41 @@ const currencyDefaults = Object.freeze({
 
 const translations = Object.freeze({
   en: {
+    // Global navigation & layout
+    skipToContent: 'Skip to content',
+    brandName: 'Marxia',
+    brandTagline: 'Coffee & Bites',
+    brandTitle: 'Marxia Café y Bocaditos',
+    brandSubtitle: 'Breakfasts, pastries & catering in Guayaquil',
+    brandSubheading: 'Breakfast bites',
+    navHome: 'Home',
+    navHomeAria: 'Return to the home page',
+    navOrder: 'Order',
+    navGallery: 'Gallery',
+    navContact: 'Contact',
+    navConsent: 'Consent management',
+    navTerms: 'Terms & Conditions',
+    quickPreferences: 'Quick preferences',
+    languageSelection: 'Language selection',
+    languageToggleToEnglish: 'Switch to English',
+    languageToggleToSpanish: 'Switch to Spanish',
+    themeSelection: 'Theme selection',
+    themeToggleDark: 'Dark',
+    themeToggleLight: 'Light',
+    themeToggleAriaDark: 'Switch to dark theme',
+    themeToggleAriaLight: 'Switch to light theme',
+    legalInfo: 'Legal information',
+    landingFooterSecurity: 'Marxia Café y Bocaditos. Security reinforced with PCI DSS, NIST CSF, and CISA best practices.',
+
+    // Landing & ordering
+    heroEyebrow: 'Guayaquil · Ecuador',
+    heroTitle: 'Signature mornings',
+    heroSubtitle: 'Choose what energizes your day.',
     headline: 'Marxia Café y Bocaditos',
     tagline: 'Breakfasts, pastries, and deliveries in North Guayaquil.',
     promise: 'Fresh flavors every day.',
-    galleryTitle: 'Our Menu',
+    deliveryCoverage: 'We deliver in North Guayaquil: Saucés · Alborada · Guayacanes · Tarazana · Brisas del Río',
+    galleryTitle: 'Our menu',
     gallerySubtitle: 'Choose what energizes your day.',
     galleryHint: 'Choose what energizes your day.',
     galleryImage1Alt: 'Freshly brewed espresso shot',
@@ -83,11 +114,160 @@ const translations = Object.freeze({
     contactDeliveryHeading: 'We deliver to:',
     contactDeliveryAreas: 'Saucés · Alborada · Guayacanes · Tarazana · Brisas del Río',
     contactWhatsAppLabel: 'WhatsApp:',
-    rights: 'All rights reserved.',
     footerConsentLink: 'Consent management',
-    footerTermsLink: 'Terms and Conditions',
+    footerTermsLink: 'Terms & Conditions',
     footerLegalContact: 'Legal contact',
+    rights: 'All rights reserved.',
     edgeSecurity: 'Edge protected via Cloudflare Zero Trust',
+
+    // Consent center UI
+    consentMetaTitle: 'Consent Management | Marxia Café y Bocaditos',
+    consentMetaDescription: 'Overview of consent, cookies, and privacy choices for Marxia Café y Bocaditos.',
+    consentHeading: 'Consent management',
+    consentTagline: 'Transparency in how we collect, use, and protect your data.',
+    consentOverviewTitle: 'Overview',
+    consentOverviewBody:
+      'Marxia Café y Bocaditos operates with privacy by design and default. We process personal information only with clear legal bases, record consent, and provide simple mechanisms so you can adjust your preferences at any time.',
+    consentDataTitle: 'Data we collect',
+    consentDataIntro: 'The information we may process is grouped as follows:',
+    consentDataEssential:
+      '<strong>Essential data:</strong> elements required to deliver the requested service, such as language selection, cart items, and delivery choices.',
+    consentDataContact:
+      '<strong>Contact data:</strong> name, email, or phone number when you choose to interact via forms or messaging channels.',
+    consentDataMetrics:
+      '<strong>Experience metrics:</strong> pseudonymised information about site usage to improve accessibility, performance, and security.',
+    consentLegalTitle: 'Legal bases for processing',
+    consentLegalIntro: 'We process your personal data under the following grounds:',
+    consentLegalConsent:
+      '<strong>Explicit consent:</strong> required for non-essential cookies, personalised marketing, and optional communications.',
+    consentLegalContract:
+      '<strong>Performance of a contract:</strong> when you request products or services and we need your details to fulfil delivery.',
+    consentLegalInterest:
+      '<strong>Legitimate interest:</strong> to prevent fraud, protect infrastructure, and improve accessibility while respecting your rights.',
+    consentCookiesTitle: 'Cookie categories and similar technologies',
+    consentCookiesCaption: 'Responsible use of cookies',
+    consentCookiesColumnCategory: 'Category',
+    consentCookiesColumnPurpose: 'Purpose',
+    consentCookiesColumnDuration: 'Duration',
+    consentCookiesColumnLegal: 'Legal basis',
+    consentCookiesEssential: 'Essential',
+    consentCookiesEssentialPurpose:
+      'Keep sessions active, remember language or accessibility preferences, and secure payments.',
+    consentCookiesEssentialDuration: 'Session or up to 12 months',
+    consentCookiesEssentialLegal: 'Contract performance / Legitimate interest',
+    consentCookiesAnalytics: 'Analytics',
+    consentCookiesAnalyticsPurpose: 'Measure visits, detect errors, and optimise the experience.',
+    consentCookiesAnalyticsDuration: '30 minutes to 24 months',
+    consentCookiesAnalyticsLegal: 'Consent',
+    consentCookiesMarketing: 'Marketing',
+    consentCookiesMarketingPurpose: 'Send relevant promotions or opt-in reminders.',
+    consentCookiesMarketingDuration: 'Until revoked',
+    consentCookiesMarketingLegal: 'Consent',
+    consentCookiesNote:
+      'Analytics and marketing cookies are disabled by default. You can manage them from the consent preference centre at the bottom of the site.',
+    consentCenterTitle: 'Dynamic preference centre',
+    consentCenterIntro:
+      'Control which optional categories you authorise in real time. Changes are saved instantly and applied across the site, honouring privacy by default.',
+    consentAcceptAll: 'Allow all',
+    consentRejectAll: 'Reject optional',
+    consentStatusIdle: 'Adjust your preferences and save changes to personalise your experience.',
+    consentStatusSaved: 'Preferences saved. You can adjust each category whenever you need.',
+    consentTimestampLabel: 'Last updated:',
+    consentEssentialCard: 'Essential',
+    consentBadgeRequired: 'Required',
+    consentEssentialCopy:
+      'Ensure the platform runs securely: sessions, language, accessibility, and order maintenance.',
+    consentEssentialAria: 'Essential cookies are always on',
+    consentSwitchActive: 'Active',
+    consentAnalyticsCard: 'Analytics',
+    consentBadgeOptional: 'Optional',
+    consentAnalyticsCopy:
+      'Help us measure performance, detect issues, and improve the experience without identifying you directly.',
+    consentAnalyticsAria: 'Toggle analytics cookies on or off',
+    consentMarketingCard: 'Marketing',
+    consentMarketingCopy:
+      'Personalise communications and campaigns that might interest you based on your tastes and previous orders.',
+    consentMarketingAria: 'Toggle marketing communications on or off',
+    consentManageTitle: 'Manage your preferences',
+    consentManageStepOne: 'Click the “Privacy preferences” button in the footer.',
+    consentManageStepTwo: 'Select each category to review its description and activate or deactivate as needed.',
+    consentManageStepThree:
+      'Save your changes. Your settings will sync across devices where you use the same account.',
+    consentManageNote: 'You can withdraw consent at any time without affecting processing carried out before the withdrawal.',
+    consentRightsTitle: 'Your privacy rights',
+    consentRightsIntro: 'Depending on your jurisdiction, you may exercise the following rights:',
+    consentRightsAccess: 'Access, rectify, and update your personal information.',
+    consentRightsDeletion: 'Delete or anonymise data when it is no longer needed.',
+    consentRightsPortability: 'Request data portability in a structured format.',
+    consentRightsObjection: 'Object to or restrict processing based on legitimate interests.',
+    consentRightsComplaint: 'File complaints with the relevant supervisory authority.',
+    consentRightsContact:
+      'To exercise these rights, email us at <a href="mailto:privacidad@marxia.ec">privacidad@marxia.ec</a> or send us a WhatsApp message.',
+    consentRetentionTitle: 'Data retention and security',
+    consentRetentionBody:
+      'We retain personal data only as long as necessary for the stated purposes or as required by law. We implement encryption, access controls, and continuous monitoring aligned with NIST CSF, CISA Cyber Essentials, and PCI DSS 4.0 to protect your information.',
+    consentUpdatesTitle: 'Updates',
+    consentUpdatesBody:
+      'We review this consent policy periodically. Significant changes will be announced via on-site banners with a visible update date. Last updated: <time datetime="2024-06-01">June 1, 2024</time>.',
+    consentFooterRights: 'Marxia Café y Bocaditos. All rights reserved.',
+    consentFooterLinksPrefix: 'Also review our',
+    consentFooterTerms: 'Terms & Conditions',
+    consentFooterAnd: 'and the',
+    consentFooterPreferences: 'preference settings',
+    consentFooterSuffix: 'to manage cookies.',
+
+    // Legal (terms)
+    termsMetaTitle: 'Terms & Conditions | Marxia Café y Bocaditos',
+    termsMetaDescription: 'Usage conditions, responsibilities, and service policies for Marxia Café y Bocaditos.',
+    termsHeading: 'Terms & Conditions',
+    termsTagline: 'Service agreement for using Marxia Café y Bocaditos digital channels.',
+    termsScopeHeading: '1. Scope and acceptance',
+    termsScopeBody:
+      'These Terms and Conditions govern access to and use of the website, applications, and related channels of Marxia Café y Bocaditos. By accessing or placing an order you agree to this agreement, the Consent Policy, and any additional guidelines published on the platform.',
+    termsServicesHeading: '2. Services offered',
+    termsServicesBody:
+      'We provide culinary experiences, reservations, and deliveries within designated areas of Guayaquil. Features and availability may vary based on seasons, capacity, or special events. Changes will be communicated through the site or official messaging channels.',
+    termsOrdersHeading: '3. Orders, payments, and billing',
+    termsOrdersConfirm:
+      'Orders are confirmed only after receiving proof of payment or manual validation.',
+    termsOrdersPayments:
+      'We accept payment methods enabled in the checkout flow, including PCI DSS compatible cards and transfers.',
+    termsOrdersInvoices:
+      'We issue electronic invoices or receipts under Ecuadorian regulations when applicable.',
+    termsOrdersPricing:
+      'Prices include applicable taxes; any additional charges will be disclosed before confirming the order.',
+    termsUserHeading: '4. User responsibilities',
+    termsUserAccurateInfo: 'Provide truthful, complete information when registering or requesting deliveries.',
+    termsUserSchedule: 'Respect delivery times and established cancellation policies.',
+    termsUserConduct: 'Do not use the site for illicit, fraudulent, or security-compromising activities.',
+    termsUserAllergens: 'Review allergen notices and nutrition facts before placing an order.',
+    termsPrivacyHeading: '5. Privacy and consent',
+    termsPrivacyBody:
+      'Personal data processing follows our <a href="consent.html">Consent Management</a>. We apply technical and organisational controls aligned with NIST CSF, CISA Cyber Essentials, and PCI DSS to safeguard confidentiality, integrity, and availability.',
+    termsIntellectualHeading: '6. Intellectual property',
+    termsIntellectualBody:
+      'All content, trademarks, logos, photographs, and designs are owned by Marxia Café y Bocaditos or its licensors. Reproducing, modifying, or distributing the material without prior written authorisation is prohibited.',
+    termsLiabilityHeading: '7. Limitation of liability',
+    termsLiabilityBody:
+      'We make reasonable efforts to provide a secure and available service. However, we are not liable for indirect damages, interruptions, or losses caused by factors beyond our control, including third-party failures, power outages, or force majeure.',
+    termsChangesHeading: '8. Modifications',
+    termsChangesBody:
+      'We may update these terms to reflect regulatory, product, or business changes. Updated versions take effect upon publication with the latest revision date. Continued use after changes signifies acceptance.',
+    termsContactHeading: '9. Contact',
+    termsContactBody:
+      'For legal questions or inquiries about these terms, email <a href="mailto:legal@marxia.ec">legal@marxia.ec</a> or reach us via WhatsApp. You can also visit our Guayaquil location by appointment.',
+    termsLawHeading: '10. Governing law and jurisdiction',
+    termsLawBody:
+      'This agreement is governed by the laws of the Republic of Ecuador. Disputes will be resolved before the competent courts of Guayaquil, without prejudice to alternative resolution mechanisms agreed by the parties.',
+    termsUpdated: 'Last updated: <time datetime="2024-06-01">June 1, 2024</time>.',
+    termsFooterRights: 'Marxia Café y Bocaditos. All rights reserved.',
+    termsFooterLinksPrefix: 'Also review our',
+    termsFooterConsent: 'Consent management',
+    termsFooterAnd: 'and the security policies applied on the',
+    termsFooterSite: 'main site',
+    termsFooterSuffix: '.',
+
+    // Drawer & FAB labels
     chatTitle: 'Live chat',
     chatWelcome: 'Hello 👋 How can we help you today?',
     chatLabel: 'Message',
@@ -104,12 +284,45 @@ const translations = Object.freeze({
     fabPayLabel: 'Payment summary',
   },
   es: {
+    // Navegación y diseño global
+    skipToContent: 'Saltar al contenido',
+    brandName: 'Marxia',
+    brandTagline: 'Café y Bocaditos',
+    brandTitle: 'Marxia Café y Bocaditos',
+    brandSubtitle: 'Desayunos, bocaditos y catering en Guayaquil',
+    brandSubheading: 'Desayunos artesanales',
+    navHome: 'Inicio',
+    navHomeAria: 'Volver a la página principal',
+    navOrder: 'Ordenar',
+    navGallery: 'Galería',
+    navContact: 'Contacto',
+    navConsent: 'Gestión de consentimiento',
+    navTerms: 'Términos y Condiciones',
+    quickPreferences: 'Preferencias rápidas',
+    languageSelection: 'Selección de idioma',
+    languageToggleToEnglish: 'Cambiar a inglés',
+    languageToggleToSpanish: 'Cambiar a español',
+    themeSelection: 'Selección de tema',
+    themeToggleDark: 'Oscuro',
+    themeToggleLight: 'Claro',
+    themeToggleAriaDark: 'Cambiar a tema oscuro',
+    themeToggleAriaLight: 'Cambiar a tema claro',
+    legalInfo: 'Información legal',
+    landingFooterSecurity:
+      'Marxia Café y Bocaditos. Seguridad reforzada con buenas prácticas PCI DSS, NIST CSF y CISA.',
+
+    // Landing y pedidos
+    heroEyebrow: 'Guayaquil · Ecuador',
+    heroTitle: 'Mañanas emblemáticas',
+    heroSubtitle: 'Elige lo que energiza tu día.',
     headline: 'Marxia Café y Bocaditos',
     tagline: 'Desayunos, bocaditos y entregas en el Norte de Guayaquil.',
     promise: 'Sabores frescos todos los días.',
-    galleryTitle: 'Our Menu',
-    gallerySubtitle: 'Elige lo que energiza su día.',
-    galleryHint: 'Elige lo que energiza su día.',
+    deliveryCoverage:
+      'Entregamos en el Norte de Guayaquil: Saucés · Alborada · Guayacanes · Tarazana · Brisas del Río',
+    galleryTitle: 'Nuestro menú',
+    gallerySubtitle: 'Elige lo que energiza tu día.',
+    galleryHint: 'Elige lo que energiza tu día.',
     galleryImage1Alt: 'Shot de espresso recién preparado',
     galleryImage2Alt: 'Bandeja de desayuno con café, tortilla, huevos y salchicha',
     galleryImage3Alt: 'Tortilla dorada sobre tabla de madera',
@@ -156,11 +369,163 @@ const translations = Object.freeze({
     contactDeliveryHeading: 'Entregamos en:',
     contactDeliveryAreas: 'Saucés · Alborada · Guayacanes · Tarazana · Brisas del Río',
     contactWhatsAppLabel: 'WhatsApp:',
-    rights: 'Todos los derechos reservados.',
     footerConsentLink: 'Gestión de consentimiento',
     footerTermsLink: 'Términos y Condiciones',
     footerLegalContact: 'Contacto legal',
+    rights: 'Todos los derechos reservados.',
     edgeSecurity: 'Protegido en el borde con Cloudflare Zero Trust',
+
+    // Centro de consentimiento
+    consentMetaTitle: 'Gestión de consentimiento | Marxia Café y Bocaditos',
+    consentMetaDescription:
+      'Resumen de consentimiento, cookies y opciones de privacidad para Marxia Café y Bocaditos.',
+    consentHeading: 'Gestión de consentimiento',
+    consentTagline: 'Transparencia en cómo recopilamos, usamos y protegemos tus datos.',
+    consentOverviewTitle: 'Resumen general',
+    consentOverviewBody:
+      'Marxia Café y Bocaditos opera con un enfoque de privacidad por diseño y por defecto. Procesamos la información personal únicamente con fundamentos legales claros, registramos el consentimiento y ofrecemos mecanismos sencillos para que puedas ajustar tus preferencias en cualquier momento.',
+    consentDataTitle: 'Datos que recopilamos',
+    consentDataIntro: 'La información que podemos procesar se clasifica de la siguiente manera:',
+    consentDataEssential:
+      '<strong>Datos esenciales:</strong> elementos necesarios para brindar el servicio solicitado, como idioma seleccionado, artículos en el carrito y opciones de entrega.',
+    consentDataContact:
+      '<strong>Datos de contacto:</strong> nombre, correo electrónico o teléfono cuando decides interactuar mediante formularios o canales de mensajería.',
+    consentDataMetrics:
+      '<strong>Métricas de experiencia:</strong> información pseudonimizada sobre el uso del sitio para mejorar accesibilidad, rendimiento y seguridad.',
+    consentLegalTitle: 'Base legal para el procesamiento',
+    consentLegalIntro: 'Procesamos tus datos personales bajo los siguientes fundamentos:',
+    consentLegalConsent:
+      '<strong>Consentimiento explícito:</strong> requerido para el uso de cookies no esenciales, marketing personalizado y comunicaciones opcionales.',
+    consentLegalContract:
+      '<strong>Ejecución de un contrato:</strong> cuando solicitas productos o servicios y necesitamos tus datos para completar la entrega.',
+    consentLegalInterest:
+      '<strong>Interés legítimo:</strong> para prevenir fraude, proteger la infraestructura y mejorar la accesibilidad del sitio, respetando siempre tus derechos.',
+    consentCookiesTitle: 'Categorías de cookies y tecnologías similares',
+    consentCookiesCaption: 'Uso responsable de cookies',
+    consentCookiesColumnCategory: 'Categoría',
+    consentCookiesColumnPurpose: 'Propósito',
+    consentCookiesColumnDuration: 'Duración',
+    consentCookiesColumnLegal: 'Base legal',
+    consentCookiesEssential: 'Esenciales',
+    consentCookiesEssentialPurpose:
+      'Mantener el inicio de sesión, recordar el idioma o preferencias de accesibilidad y asegurar la integridad de pagos.',
+    consentCookiesEssentialDuration: 'Sesión o hasta 12 meses',
+    consentCookiesEssentialLegal: 'Ejecución de contrato / Interés legítimo',
+    consentCookiesAnalytics: 'Analíticas',
+    consentCookiesAnalyticsPurpose: 'Medir visitas, detectar errores y optimizar la experiencia.',
+    consentCookiesAnalyticsDuration: '30 minutos a 24 meses',
+    consentCookiesAnalyticsLegal: 'Consentimiento',
+    consentCookiesMarketing: 'Marketing',
+    consentCookiesMarketingPurpose: 'Enviar promociones relevantes o recordatorios opt-in.',
+    consentCookiesMarketingDuration: 'Hasta revocación',
+    consentCookiesMarketingLegal: 'Consentimiento',
+    consentCookiesNote:
+      'Las cookies analíticas y de marketing están desactivadas por defecto. Puedes gestionarlas desde el Centro de Preferencias de Consentimiento en la parte inferior del sitio.',
+    consentCenterTitle: 'Centro de preferencias dinámico',
+    consentCenterIntro:
+      'Controla qué categorías opcionales autorizas en tiempo real. Los cambios se guardan al instante y aplican al resto del sitio, respetando el principio de privacidad por defecto.',
+    consentAcceptAll: 'Permitir todo',
+    consentRejectAll: 'Rechazar opcionales',
+    consentStatusIdle: 'Ajusta tus preferencias y guarda los cambios para personalizar tu experiencia.',
+    consentStatusSaved: 'Preferencias guardadas. Puedes ajustar cada categoría cuando lo necesites.',
+    consentTimestampLabel: 'Última actualización:',
+    consentEssentialCard: 'Esenciales',
+    consentBadgeRequired: 'Necesario',
+    consentEssentialCopy:
+      'Garantizan que la plataforma funcione de forma segura: inicio de sesión, idioma, accesibilidad y mantenimiento de pedidos.',
+    consentEssentialAria: 'Las cookies esenciales siempre están activas',
+    consentSwitchActive: 'Activo',
+    consentAnalyticsCard: 'Analíticas',
+    consentBadgeOptional: 'Opcional',
+    consentAnalyticsCopy:
+      'Nos ayudan a medir el rendimiento, detectar incidencias y mejorar la experiencia sin identificarte directamente.',
+    consentAnalyticsAria: 'Activar o desactivar cookies analíticas',
+    consentMarketingCard: 'Marketing',
+    consentMarketingCopy:
+      'Personalizan comunicaciones y campañas que podrían interesarte según tus gustos y pedidos previos.',
+    consentMarketingAria: 'Activar o desactivar comunicaciones de marketing',
+    consentManageTitle: 'Gestiona tus preferencias',
+    consentManageStepOne: 'Haz clic en el botón “Preferencias de privacidad” en el pie de página.',
+    consentManageStepTwo: 'Selecciona cada categoría para ver su descripción y activar o desactivar según tus necesidades.',
+    consentManageStepThree:
+      'Guarda los cambios. Tus ajustes se sincronizarán en todos los dispositivos donde utilices la misma cuenta.',
+    consentManageNote:
+      'Siempre podrás retirar tu consentimiento sin afectar la legalidad del procesamiento previo a la revocación.',
+    consentRightsTitle: 'Tus derechos de privacidad',
+    consentRightsIntro: 'Dependiendo de tu jurisdicción, puedes ejercer los siguientes derechos:',
+    consentRightsAccess: 'Acceso, rectificación y actualización de tu información personal.',
+    consentRightsDeletion: 'Eliminación o anonimización de datos cuando ya no sean necesarios.',
+    consentRightsPortability: 'Portabilidad de datos en un formato estructurado.',
+    consentRightsObjection: 'Oposición o restricción al procesamiento basado en intereses legítimos.',
+    consentRightsComplaint: 'Presentar quejas ante la autoridad de control competente.',
+    consentRightsContact:
+      'Para ejercer estos derechos, escríbenos a <a href="mailto:privacidad@marxia.ec">privacidad@marxia.ec</a> o envíanos un mensaje vía WhatsApp.',
+    consentRetentionTitle: 'Conservación y seguridad de los datos',
+    consentRetentionBody:
+      'Conservamos los datos personales únicamente durante el tiempo necesario para cumplir con los fines descritos o según lo requiera la ley aplicable. Implementamos cifrado, controles de acceso y monitoreo continuo conforme a NIST CSF, CISA Cyber Essentials y PCI DSS 4.0 para proteger tu información.',
+    consentUpdatesTitle: 'Actualizaciones',
+    consentUpdatesBody:
+      'Revisamos esta política de consentimiento de manera periódica. Notificaremos cambios sustanciales mediante banners en el sitio y una fecha de actualización visible. Última actualización: <time datetime="2024-06-01">1 de junio de 2024</time>.',
+    consentFooterRights: 'Marxia Café y Bocaditos. Todos los derechos reservados.',
+    consentFooterLinksPrefix: 'Consulta también nuestros',
+    consentFooterTerms: 'Términos y Condiciones',
+    consentFooterAnd: 'y la',
+    consentFooterPreferences: 'configuración de preferencias',
+    consentFooterSuffix: 'para administrar cookies.',
+
+    // Términos legales
+    termsMetaTitle: 'Términos y Condiciones | Marxia Café y Bocaditos',
+    termsMetaDescription:
+      'Condiciones de uso, responsabilidades y políticas de servicio de Marxia Café y Bocaditos.',
+    termsHeading: 'Términos y Condiciones',
+    termsTagline: 'Acuerdo de servicio para utilizar los canales digitales de Marxia Café y Bocaditos.',
+    termsScopeHeading: '1. Alcance y aceptación',
+    termsScopeBody:
+      'Estos Términos y Condiciones regulan el acceso y uso del sitio web, aplicaciones y canales asociados de Marxia Café y Bocaditos. Al acceder o realizar un pedido aceptas cumplir este acuerdo, la Política de Consentimiento y cualquier lineamiento complementario publicado en la plataforma.',
+    termsServicesHeading: '2. Servicios ofrecidos',
+    termsServicesBody:
+      'Ofrecemos experiencias gastronómicas, reservas y entregas a domicilio dentro de las zonas habilitadas de Guayaquil. Las características y disponibilidad pueden variar según temporadas, aforo y eventos especiales. Cualquier cambio será comunicado mediante el sitio o canales oficiales de mensajería.',
+    termsOrdersHeading: '3. Pedidos, pagos y facturación',
+    termsOrdersConfirm:
+      'Los pedidos se considerarán confirmados únicamente tras recibir un comprobante de pago o validación manual.',
+    termsOrdersPayments:
+      'Aceptamos métodos de pago habilitados en el flujo de checkout, incluyendo tarjetas compatibles con PCI DSS y transferencias.',
+    termsOrdersInvoices:
+      'Emitimos facturas o comprobantes electrónicos bajo normativa ecuatoriana cuando corresponda.',
+    termsOrdersPricing:
+      'Los precios incluyen impuestos aplicables; cualquier cargo adicional se informará antes de confirmar la orden.',
+    termsUserHeading: '4. Responsabilidades del usuario',
+    termsUserAccurateInfo: 'Proporcionar información veraz y completa al registrarse o solicitar entregas.',
+    termsUserSchedule: 'Respetar horarios de entrega y políticas de cancelación establecidas.',
+    termsUserConduct: 'No utilizar el sitio para actividades ilícitas, fraudulentas o que comprometan la seguridad.',
+    termsUserAllergens: 'Revisar las alertas de alérgenos y fichas nutricionales antes de realizar un pedido.',
+    termsPrivacyHeading: '5. Privacidad y consentimiento',
+    termsPrivacyBody:
+      'El tratamiento de datos personales se rige por nuestra <a href="consent.html">Gestión de consentimiento</a>. Utilizamos controles técnicos y organizativos alineados con NIST CSF, CISA Cyber Essentials y PCI DSS para salvaguardar la confidencialidad, integridad y disponibilidad de tu información.',
+    termsIntellectualHeading: '6. Propiedad intelectual',
+    termsIntellectualBody:
+      'Todos los contenidos, marcas, logotipos, fotografías y diseños son propiedad de Marxia Café y Bocaditos o de sus licenciantes. No se permite reproducir, modificar o distribuir el material sin autorización escrita previa.',
+    termsLiabilityHeading: '7. Limitación de responsabilidad',
+    termsLiabilityBody:
+      'Hacemos esfuerzos razonables por garantizar un servicio seguro y disponible. Sin embargo, no asumimos responsabilidad por daños indirectos, interrupciones o pérdidas derivadas de causas fuera de nuestro control, incluyendo fallos de terceros, cortes eléctricos o eventos de fuerza mayor.',
+    termsChangesHeading: '8. Modificaciones',
+    termsChangesBody:
+      'Podemos actualizar estos términos para reflejar cambios regulatorios, de producto o de negocio. Las versiones modificadas entrarán en vigencia al publicarse en esta página, indicando la fecha de última actualización. El uso continuado posterior a los cambios implica tu aceptación.',
+    termsContactHeading: '9. Contacto',
+    termsContactBody:
+      'Si tienes consultas legales o sobre estos términos, escríbenos a <a href="mailto:legal@marxia.ec">legal@marxia.ec</a> o contáctanos mediante WhatsApp. También puedes visitar nuestra sede en Guayaquil previa cita.',
+    termsLawHeading: '10. Ley aplicable y jurisdicción',
+    termsLawBody:
+      'Este acuerdo se rige por las leyes de la República del Ecuador. Cualquier controversia se resolverá ante los tribunales competentes de Guayaquil, sin perjuicio de mecanismos alternativos de resolución que las partes acuerden.',
+    termsUpdated: 'Última actualización: <time datetime="2024-06-01">1 de junio de 2024</time>.',
+    termsFooterRights: 'Marxia Café y Bocaditos. Todos los derechos reservados.',
+    termsFooterLinksPrefix: 'Revisa también nuestra',
+    termsFooterConsent: 'Gestión de consentimiento',
+    termsFooterAnd: 'y las políticas de seguridad aplicadas en el',
+    termsFooterSite: 'sitio principal',
+    termsFooterSuffix: '.',
+
+    // Etiquetas de cajones y FAB
     chatTitle: 'Chat en vivo',
     chatWelcome: 'Hola 👋 ¿En qué podemos ayudarte hoy?',
     chatLabel: 'Mensaje',
@@ -420,6 +785,10 @@ function createCartStore({ taxRate = 0, deliveryFee = 0 } = {}) {
   let carouselPaginationButtons = [];
   let lastCarouselPageCount = 0;
   const i18n = createI18nManager({ html });
+  if (typeof window !== 'undefined') {
+    window.marxia = window.marxia || {};
+    window.marxia.i18n = i18n;
+  }
   let currentLanguage = i18n.language;
   let selectedDeliveryTime = null;
   const isSmallScreen = () => smallScreenQuery.matches;
@@ -954,8 +1323,10 @@ function createCartStore({ taxRate = 0, deliveryFee = 0 } = {}) {
     updateFabMenuSelection();
     if (themeToggle) {
       const isDark = nextTheme === 'dark';
-      themeToggle.textContent = isDark ? 'Light' : 'Dark';
-      themeToggle.setAttribute('aria-label', isDark ? 'Switch to light theme' : 'Switch to dark theme');
+      const labelKey = isDark ? 'themeToggleLight' : 'themeToggleDark';
+      const ariaKey = isDark ? 'themeToggleAriaLight' : 'themeToggleAriaDark';
+      themeToggle.textContent = getTranslation(labelKey);
+      themeToggle.setAttribute('aria-label', getTranslation(ariaKey));
       themeToggle.setAttribute('aria-pressed', String(isDark));
     }
   };
@@ -968,10 +1339,8 @@ function createCartStore({ taxRate = 0, deliveryFee = 0 } = {}) {
       const isSpanish = nextLang === 'es';
       languageToggle.setAttribute('data-current-language', nextLang);
       languageToggle.setAttribute('aria-checked', String(!isSpanish));
-      languageToggle.setAttribute(
-        'aria-label',
-        isSpanish ? 'Switch to English' : 'Cambiar a Español'
-      );
+      const ariaKey = isSpanish ? 'languageToggleToEnglish' : 'languageToggleToSpanish';
+      languageToggle.setAttribute('aria-label', getTranslation(ariaKey));
       languageToggle.textContent = nextLang.toUpperCase();
     }
 
@@ -997,7 +1366,11 @@ function createCartStore({ taxRate = 0, deliveryFee = 0 } = {}) {
         return;
       }
 
-      node.textContent = translation;
+      if (node.dataset.i18nHtml === 'true') {
+        node.innerHTML = translation;
+      } else {
+        node.textContent = translation;
+      }
     });
 
     document.querySelectorAll('[data-i18n-placeholder]').forEach((node) => {
@@ -1006,6 +1379,14 @@ function createCartStore({ taxRate = 0, deliveryFee = 0 } = {}) {
         node.setAttribute('placeholder', dict[key]);
       }
     });
+
+    if (typeof document !== 'undefined' && typeof CustomEvent === 'function') {
+      document.dispatchEvent(
+        new CustomEvent('marxia:language-change', {
+          detail: { language: nextLang },
+        })
+      );
+    }
 
     updateDeliveryOptionLabels(nextLang);
     syncSelectedDeliveryLabel();
@@ -1016,6 +1397,7 @@ function createCartStore({ taxRate = 0, deliveryFee = 0 } = {}) {
     updateProductPrices();
     updateCartDisplay();
     refreshCarouselPagination();
+    applyTheme(html.dataset.theme);
   };
 
   const restorePreferences = () => {

--- a/order.html
+++ b/order.html
@@ -42,22 +42,22 @@
   </script>
 </head>
 <body>
-  <a class="skip-link" href="#mainContent">Saltar al contenido</a>
+  <a class="skip-link" href="#mainContent" data-i18n="skipToContent">Saltar al contenido</a>
   <header class="topbar" role="banner">
     <div class="topbar__brand">
-      <a href="index.html" class="topbar__home" aria-label="Volver a la página principal">
+      <a href="index.html" class="topbar__home" aria-label="Volver a la página principal" data-i18n="navHomeAria" data-i18n-attr="aria-label" data-i18n-skip-text="true">
         <span aria-hidden="true" class="logo">☕</span>
-        <span class="topbar__home-text">Inicio</span>
+        <span class="topbar__home-text" data-i18n="navHome">Inicio</span>
       </a>
       <p>
-        <strong id="brandTitle">Marxia Café y Bocaditos</strong>
-        <span id="brandSubtitle">Breakfasts, pastries &amp; catering in Guayaquil</span>
-        <span data-i18n="contactWhatsAppLabel">WhatsApp:</span><a href="https://wa.me/593958741463" 
+        <strong id="brandTitle" data-i18n="brandTitle">Marxia Café y Bocaditos</strong>
+        <span id="brandSubtitle" data-i18n="brandSubtitle">Breakfasts, pastries &amp; catering in Guayaquil</span>
+        <span data-i18n="contactWhatsAppLabel">WhatsApp:</span><a href="https://wa.me/593958741463"
         target="_blank" rel="noopener noreferrer" aria-label="WhatsApp +593 958 741 463">+593 958 741 463</a>
       </p>
     </div>
- <nav aria-label="Preferencias rápidas" class="landing__toggles">
-        <div class="toggle-group" role="group" aria-label="Language selection">
+ <nav aria-label="Preferencias rápidas" class="landing__toggles" data-i18n="quickPreferences" data-i18n-attr="aria-label" data-i18n-skip-text="true">
+        <div class="toggle-group" role="group" aria-label="Language selection" data-i18n="languageSelection" data-i18n-attr="aria-label" data-i18n-skip-text="true">
           <button
             class="toggle-button toggle-button--language"
             id="languageToggle"
@@ -68,15 +68,15 @@
             data-current-language="es"
           >ES</button>
         </div>
-      
-        <div class="toggle-group" role="group" aria-label="Theme selection">
+
+        <div class="toggle-group" role="group" aria-label="Theme selection" data-i18n="themeSelection" data-i18n-attr="aria-label" data-i18n-skip-text="true">
           <button
             class="toggle-button toggle-button--theme"
             id="themeToggle"
             type="button"
             aria-pressed="false"
-            aria-label="Switch to dark theme"
-          >Dark</button>
+            aria-label="Cambiar a tema oscuro"
+          >Oscuro</button>
         </div>
       </nav>
   </header>

--- a/src/js/i18n/dictionary.js
+++ b/src/js/i18n/dictionary.js
@@ -1,9 +1,40 @@
 export const translations = Object.freeze({
   en: {
+    // Global navigation & layout
+    skipToContent: 'Skip to content',
+    brandName: 'Marxia',
+    brandTagline: 'Coffee & Bites',
+    brandTitle: 'Marxia Café y Bocaditos',
+    brandSubtitle: 'Breakfasts, pastries & catering in Guayaquil',
+    brandSubheading: 'Breakfast bites',
+    navHome: 'Home',
+    navHomeAria: 'Return to the home page',
+    navOrder: 'Order',
+    navGallery: 'Gallery',
+    navContact: 'Contact',
+    navConsent: 'Consent management',
+    navTerms: 'Terms & Conditions',
+    quickPreferences: 'Quick preferences',
+    languageSelection: 'Language selection',
+    languageToggleToEnglish: 'Switch to English',
+    languageToggleToSpanish: 'Switch to Spanish',
+    themeSelection: 'Theme selection',
+    themeToggleDark: 'Dark',
+    themeToggleLight: 'Light',
+    themeToggleAriaDark: 'Switch to dark theme',
+    themeToggleAriaLight: 'Switch to light theme',
+    legalInfo: 'Legal information',
+    landingFooterSecurity: 'Marxia Café y Bocaditos. Security reinforced with PCI DSS, NIST CSF, and CISA best practices.',
+
+    // Landing & ordering
+    heroEyebrow: 'Guayaquil · Ecuador',
+    heroTitle: 'Signature mornings',
+    heroSubtitle: 'Choose what energizes your day.',
     headline: 'Marxia Café y Bocaditos',
     tagline: 'Breakfasts, pastries, and deliveries in North Guayaquil.',
     promise: 'Fresh flavors every day.',
-    galleryTitle: 'Our Menu',
+    deliveryCoverage: 'We deliver in North Guayaquil: Saucés · Alborada · Guayacanes · Tarazana · Brisas del Río',
+    galleryTitle: 'Our menu',
     gallerySubtitle: 'Choose what energizes your day.',
     galleryHint: 'Choose what energizes your day.',
     galleryImage1Alt: 'Freshly brewed espresso shot',
@@ -52,8 +83,160 @@ export const translations = Object.freeze({
     contactDeliveryHeading: 'We deliver to:',
     contactDeliveryAreas: 'Saucés · Alborada · Guayacanes · Tarazana · Brisas del Río',
     contactWhatsAppLabel: 'WhatsApp:',
+    footerConsentLink: 'Consent management',
+    footerTermsLink: 'Terms & Conditions',
+    footerLegalContact: 'Legal contact',
     rights: 'All rights reserved.',
     edgeSecurity: 'Edge protected via Cloudflare Zero Trust',
+
+    // Consent center UI
+    consentMetaTitle: 'Consent Management | Marxia Café y Bocaditos',
+    consentMetaDescription: 'Overview of consent, cookies, and privacy choices for Marxia Café y Bocaditos.',
+    consentHeading: 'Consent management',
+    consentTagline: 'Transparency in how we collect, use, and protect your data.',
+    consentOverviewTitle: 'Overview',
+    consentOverviewBody:
+      'Marxia Café y Bocaditos operates with privacy by design and default. We process personal information only with clear legal bases, record consent, and provide simple mechanisms so you can adjust your preferences at any time.',
+    consentDataTitle: 'Data we collect',
+    consentDataIntro: 'The information we may process is grouped as follows:',
+    consentDataEssential:
+      '<strong>Essential data:</strong> elements required to deliver the requested service, such as language selection, cart items, and delivery choices.',
+    consentDataContact:
+      '<strong>Contact data:</strong> name, email, or phone number when you choose to interact via forms or messaging channels.',
+    consentDataMetrics:
+      '<strong>Experience metrics:</strong> pseudonymised information about site usage to improve accessibility, performance, and security.',
+    consentLegalTitle: 'Legal bases for processing',
+    consentLegalIntro: 'We process your personal data under the following grounds:',
+    consentLegalConsent:
+      '<strong>Explicit consent:</strong> required for non-essential cookies, personalised marketing, and optional communications.',
+    consentLegalContract:
+      '<strong>Performance of a contract:</strong> when you request products or services and we need your details to fulfil delivery.',
+    consentLegalInterest:
+      '<strong>Legitimate interest:</strong> to prevent fraud, protect infrastructure, and improve accessibility while respecting your rights.',
+    consentCookiesTitle: 'Cookie categories and similar technologies',
+    consentCookiesCaption: 'Responsible use of cookies',
+    consentCookiesColumnCategory: 'Category',
+    consentCookiesColumnPurpose: 'Purpose',
+    consentCookiesColumnDuration: 'Duration',
+    consentCookiesColumnLegal: 'Legal basis',
+    consentCookiesEssential: 'Essential',
+    consentCookiesEssentialPurpose:
+      'Keep sessions active, remember language or accessibility preferences, and secure payments.',
+    consentCookiesEssentialDuration: 'Session or up to 12 months',
+    consentCookiesEssentialLegal: 'Contract performance / Legitimate interest',
+    consentCookiesAnalytics: 'Analytics',
+    consentCookiesAnalyticsPurpose: 'Measure visits, detect errors, and optimise the experience.',
+    consentCookiesAnalyticsDuration: '30 minutes to 24 months',
+    consentCookiesAnalyticsLegal: 'Consent',
+    consentCookiesMarketing: 'Marketing',
+    consentCookiesMarketingPurpose: 'Send relevant promotions or opt-in reminders.',
+    consentCookiesMarketingDuration: 'Until revoked',
+    consentCookiesMarketingLegal: 'Consent',
+    consentCookiesNote:
+      'Analytics and marketing cookies are disabled by default. You can manage them from the consent preference centre at the bottom of the site.',
+    consentCenterTitle: 'Dynamic preference centre',
+    consentCenterIntro:
+      'Control which optional categories you authorise in real time. Changes are saved instantly and applied across the site, honouring privacy by default.',
+    consentAcceptAll: 'Allow all',
+    consentRejectAll: 'Reject optional',
+    consentStatusIdle: 'Adjust your preferences and save changes to personalise your experience.',
+    consentStatusSaved: 'Preferences saved. You can adjust each category whenever you need.',
+    consentTimestampLabel: 'Last updated:',
+    consentEssentialCard: 'Essential',
+    consentBadgeRequired: 'Required',
+    consentEssentialCopy:
+      'Ensure the platform runs securely: sessions, language, accessibility, and order maintenance.',
+    consentEssentialAria: 'Essential cookies are always on',
+    consentSwitchActive: 'Active',
+    consentAnalyticsCard: 'Analytics',
+    consentBadgeOptional: 'Optional',
+    consentAnalyticsCopy:
+      'Help us measure performance, detect issues, and improve the experience without identifying you directly.',
+    consentAnalyticsAria: 'Toggle analytics cookies on or off',
+    consentMarketingCard: 'Marketing',
+    consentMarketingCopy:
+      'Personalise communications and campaigns that might interest you based on your tastes and previous orders.',
+    consentMarketingAria: 'Toggle marketing communications on or off',
+    consentManageTitle: 'Manage your preferences',
+    consentManageStepOne: 'Click the “Privacy preferences” button in the footer.',
+    consentManageStepTwo: 'Select each category to review its description and activate or deactivate as needed.',
+    consentManageStepThree:
+      'Save your changes. Your settings will sync across devices where you use the same account.',
+    consentManageNote: 'You can withdraw consent at any time without affecting processing carried out before the withdrawal.',
+    consentRightsTitle: 'Your privacy rights',
+    consentRightsIntro: 'Depending on your jurisdiction, you may exercise the following rights:',
+    consentRightsAccess: 'Access, rectify, and update your personal information.',
+    consentRightsDeletion: 'Delete or anonymise data when it is no longer needed.',
+    consentRightsPortability: 'Request data portability in a structured format.',
+    consentRightsObjection: 'Object to or restrict processing based on legitimate interests.',
+    consentRightsComplaint: 'File complaints with the relevant supervisory authority.',
+    consentRightsContact:
+      'To exercise these rights, email us at <a href="mailto:privacidad@marxia.ec">privacidad@marxia.ec</a> or send us a WhatsApp message.',
+    consentRetentionTitle: 'Data retention and security',
+    consentRetentionBody:
+      'We retain personal data only as long as necessary for the stated purposes or as required by law. We implement encryption, access controls, and continuous monitoring aligned with NIST CSF, CISA Cyber Essentials, and PCI DSS 4.0 to protect your information.',
+    consentUpdatesTitle: 'Updates',
+    consentUpdatesBody:
+      'We review this consent policy periodically. Significant changes will be announced via on-site banners with a visible update date. Last updated: <time datetime="2024-06-01">June 1, 2024</time>.',
+    consentFooterRights: 'Marxia Café y Bocaditos. All rights reserved.',
+    consentFooterLinksPrefix: 'Also review our',
+    consentFooterTerms: 'Terms & Conditions',
+    consentFooterAnd: 'and the',
+    consentFooterPreferences: 'preference settings',
+    consentFooterSuffix: 'to manage cookies.',
+
+    // Legal (terms)
+    termsMetaTitle: 'Terms & Conditions | Marxia Café y Bocaditos',
+    termsMetaDescription: 'Usage conditions, responsibilities, and service policies for Marxia Café y Bocaditos.',
+    termsHeading: 'Terms & Conditions',
+    termsTagline: 'Service agreement for using Marxia Café y Bocaditos digital channels.',
+    termsScopeHeading: '1. Scope and acceptance',
+    termsScopeBody:
+      'These Terms and Conditions govern access to and use of the website, applications, and related channels of Marxia Café y Bocaditos. By accessing or placing an order you agree to this agreement, the Consent Policy, and any additional guidelines published on the platform.',
+    termsServicesHeading: '2. Services offered',
+    termsServicesBody:
+      'We provide culinary experiences, reservations, and deliveries within designated areas of Guayaquil. Features and availability may vary based on seasons, capacity, or special events. Changes will be communicated through the site or official messaging channels.',
+    termsOrdersHeading: '3. Orders, payments, and billing',
+    termsOrdersConfirm:
+      'Orders are confirmed only after receiving proof of payment or manual validation.',
+    termsOrdersPayments:
+      'We accept payment methods enabled in the checkout flow, including PCI DSS compatible cards and transfers.',
+    termsOrdersInvoices:
+      'We issue electronic invoices or receipts under Ecuadorian regulations when applicable.',
+    termsOrdersPricing:
+      'Prices include applicable taxes; any additional charges will be disclosed before confirming the order.',
+    termsUserHeading: '4. User responsibilities',
+    termsUserAccurateInfo: 'Provide truthful, complete information when registering or requesting deliveries.',
+    termsUserSchedule: 'Respect delivery times and established cancellation policies.',
+    termsUserConduct: 'Do not use the site for illicit, fraudulent, or security-compromising activities.',
+    termsUserAllergens: 'Review allergen notices and nutrition facts before placing an order.',
+    termsPrivacyHeading: '5. Privacy and consent',
+    termsPrivacyBody:
+      'Personal data processing follows our <a href="consent.html">Consent Management</a>. We apply technical and organisational controls aligned with NIST CSF, CISA Cyber Essentials, and PCI DSS to safeguard confidentiality, integrity, and availability.',
+    termsIntellectualHeading: '6. Intellectual property',
+    termsIntellectualBody:
+      'All content, trademarks, logos, photographs, and designs are owned by Marxia Café y Bocaditos or its licensors. Reproducing, modifying, or distributing the material without prior written authorisation is prohibited.',
+    termsLiabilityHeading: '7. Limitation of liability',
+    termsLiabilityBody:
+      'We make reasonable efforts to provide a secure and available service. However, we are not liable for indirect damages, interruptions, or losses caused by factors beyond our control, including third-party failures, power outages, or force majeure.',
+    termsChangesHeading: '8. Modifications',
+    termsChangesBody:
+      'We may update these terms to reflect regulatory, product, or business changes. Updated versions take effect upon publication with the latest revision date. Continued use after changes signifies acceptance.',
+    termsContactHeading: '9. Contact',
+    termsContactBody:
+      'For legal questions or inquiries about these terms, email <a href="mailto:legal@marxia.ec">legal@marxia.ec</a> or reach us via WhatsApp. You can also visit our Guayaquil location by appointment.',
+    termsLawHeading: '10. Governing law and jurisdiction',
+    termsLawBody:
+      'This agreement is governed by the laws of the Republic of Ecuador. Disputes will be resolved before the competent courts of Guayaquil, without prejudice to alternative resolution mechanisms agreed by the parties.',
+    termsUpdated: 'Last updated: <time datetime="2024-06-01">June 1, 2024</time>.',
+    termsFooterRights: 'Marxia Café y Bocaditos. All rights reserved.',
+    termsFooterLinksPrefix: 'Also review our',
+    termsFooterConsent: 'Consent management',
+    termsFooterAnd: 'and the security policies applied on the',
+    termsFooterSite: 'main site',
+    termsFooterSuffix: '.',
+
+    // Drawer & FAB labels
     chatTitle: 'Live chat',
     chatWelcome: 'Hello 👋 How can we help you today?',
     chatLabel: 'Message',
@@ -70,12 +253,45 @@ export const translations = Object.freeze({
     fabPayLabel: 'Payment summary',
   },
   es: {
+    // Navegación y diseño global
+    skipToContent: 'Saltar al contenido',
+    brandName: 'Marxia',
+    brandTagline: 'Café y Bocaditos',
+    brandTitle: 'Marxia Café y Bocaditos',
+    brandSubtitle: 'Desayunos, bocaditos y catering en Guayaquil',
+    brandSubheading: 'Desayunos artesanales',
+    navHome: 'Inicio',
+    navHomeAria: 'Volver a la página principal',
+    navOrder: 'Ordenar',
+    navGallery: 'Galería',
+    navContact: 'Contacto',
+    navConsent: 'Gestión de consentimiento',
+    navTerms: 'Términos y Condiciones',
+    quickPreferences: 'Preferencias rápidas',
+    languageSelection: 'Selección de idioma',
+    languageToggleToEnglish: 'Cambiar a inglés',
+    languageToggleToSpanish: 'Cambiar a español',
+    themeSelection: 'Selección de tema',
+    themeToggleDark: 'Oscuro',
+    themeToggleLight: 'Claro',
+    themeToggleAriaDark: 'Cambiar a tema oscuro',
+    themeToggleAriaLight: 'Cambiar a tema claro',
+    legalInfo: 'Información legal',
+    landingFooterSecurity:
+      'Marxia Café y Bocaditos. Seguridad reforzada con buenas prácticas PCI DSS, NIST CSF y CISA.',
+
+    // Landing y pedidos
+    heroEyebrow: 'Guayaquil · Ecuador',
+    heroTitle: 'Mañanas emblemáticas',
+    heroSubtitle: 'Elige lo que energiza tu día.',
     headline: 'Marxia Café y Bocaditos',
     tagline: 'Desayunos, bocaditos y entregas en el Norte de Guayaquil.',
     promise: 'Sabores frescos todos los días.',
-    galleryTitle: 'Our Menu',
-    gallerySubtitle: 'Elige lo que energiza su día.',
-    galleryHint: 'Elige lo que energiza su día.',
+    deliveryCoverage:
+      'Entregamos en el Norte de Guayaquil: Saucés · Alborada · Guayacanes · Tarazana · Brisas del Río',
+    galleryTitle: 'Nuestro menú',
+    gallerySubtitle: 'Elige lo que energiza tu día.',
+    galleryHint: 'Elige lo que energiza tu día.',
     galleryImage1Alt: 'Shot de espresso recién preparado',
     galleryImage2Alt: 'Bandeja de desayuno con café, tortilla, huevos y salchicha',
     galleryImage3Alt: 'Tortilla dorada sobre tabla de madera',
@@ -122,8 +338,163 @@ export const translations = Object.freeze({
     contactDeliveryHeading: 'Entregamos en:',
     contactDeliveryAreas: 'Saucés · Alborada · Guayacanes · Tarazana · Brisas del Río',
     contactWhatsAppLabel: 'WhatsApp:',
+    footerConsentLink: 'Gestión de consentimiento',
+    footerTermsLink: 'Términos y Condiciones',
+    footerLegalContact: 'Contacto legal',
     rights: 'Todos los derechos reservados.',
     edgeSecurity: 'Protegido en el borde con Cloudflare Zero Trust',
+
+    // Centro de consentimiento
+    consentMetaTitle: 'Gestión de consentimiento | Marxia Café y Bocaditos',
+    consentMetaDescription:
+      'Resumen de consentimiento, cookies y opciones de privacidad para Marxia Café y Bocaditos.',
+    consentHeading: 'Gestión de consentimiento',
+    consentTagline: 'Transparencia en cómo recopilamos, usamos y protegemos tus datos.',
+    consentOverviewTitle: 'Resumen general',
+    consentOverviewBody:
+      'Marxia Café y Bocaditos opera con un enfoque de privacidad por diseño y por defecto. Procesamos la información personal únicamente con fundamentos legales claros, registramos el consentimiento y ofrecemos mecanismos sencillos para que puedas ajustar tus preferencias en cualquier momento.',
+    consentDataTitle: 'Datos que recopilamos',
+    consentDataIntro: 'La información que podemos procesar se clasifica de la siguiente manera:',
+    consentDataEssential:
+      '<strong>Datos esenciales:</strong> elementos necesarios para brindar el servicio solicitado, como idioma seleccionado, artículos en el carrito y opciones de entrega.',
+    consentDataContact:
+      '<strong>Datos de contacto:</strong> nombre, correo electrónico o teléfono cuando decides interactuar mediante formularios o canales de mensajería.',
+    consentDataMetrics:
+      '<strong>Métricas de experiencia:</strong> información pseudonimizada sobre el uso del sitio para mejorar accesibilidad, rendimiento y seguridad.',
+    consentLegalTitle: 'Base legal para el procesamiento',
+    consentLegalIntro: 'Procesamos tus datos personales bajo los siguientes fundamentos:',
+    consentLegalConsent:
+      '<strong>Consentimiento explícito:</strong> requerido para el uso de cookies no esenciales, marketing personalizado y comunicaciones opcionales.',
+    consentLegalContract:
+      '<strong>Ejecución de un contrato:</strong> cuando solicitas productos o servicios y necesitamos tus datos para completar la entrega.',
+    consentLegalInterest:
+      '<strong>Interés legítimo:</strong> para prevenir fraude, proteger la infraestructura y mejorar la accesibilidad del sitio, respetando siempre tus derechos.',
+    consentCookiesTitle: 'Categorías de cookies y tecnologías similares',
+    consentCookiesCaption: 'Uso responsable de cookies',
+    consentCookiesColumnCategory: 'Categoría',
+    consentCookiesColumnPurpose: 'Propósito',
+    consentCookiesColumnDuration: 'Duración',
+    consentCookiesColumnLegal: 'Base legal',
+    consentCookiesEssential: 'Esenciales',
+    consentCookiesEssentialPurpose:
+      'Mantener el inicio de sesión, recordar el idioma o preferencias de accesibilidad y asegurar la integridad de pagos.',
+    consentCookiesEssentialDuration: 'Sesión o hasta 12 meses',
+    consentCookiesEssentialLegal: 'Ejecución de contrato / Interés legítimo',
+    consentCookiesAnalytics: 'Analíticas',
+    consentCookiesAnalyticsPurpose: 'Medir visitas, detectar errores y optimizar la experiencia.',
+    consentCookiesAnalyticsDuration: '30 minutos a 24 meses',
+    consentCookiesAnalyticsLegal: 'Consentimiento',
+    consentCookiesMarketing: 'Marketing',
+    consentCookiesMarketingPurpose: 'Enviar promociones relevantes o recordatorios opt-in.',
+    consentCookiesMarketingDuration: 'Hasta revocación',
+    consentCookiesMarketingLegal: 'Consentimiento',
+    consentCookiesNote:
+      'Las cookies analíticas y de marketing están desactivadas por defecto. Puedes gestionarlas desde el Centro de Preferencias de Consentimiento en la parte inferior del sitio.',
+    consentCenterTitle: 'Centro de preferencias dinámico',
+    consentCenterIntro:
+      'Controla qué categorías opcionales autorizas en tiempo real. Los cambios se guardan al instante y aplican al resto del sitio, respetando el principio de privacidad por defecto.',
+    consentAcceptAll: 'Permitir todo',
+    consentRejectAll: 'Rechazar opcionales',
+    consentStatusIdle: 'Ajusta tus preferencias y guarda los cambios para personalizar tu experiencia.',
+    consentStatusSaved: 'Preferencias guardadas. Puedes ajustar cada categoría cuando lo necesites.',
+    consentTimestampLabel: 'Última actualización:',
+    consentEssentialCard: 'Esenciales',
+    consentBadgeRequired: 'Necesario',
+    consentEssentialCopy:
+      'Garantizan que la plataforma funcione de forma segura: inicio de sesión, idioma, accesibilidad y mantenimiento de pedidos.',
+    consentEssentialAria: 'Las cookies esenciales siempre están activas',
+    consentSwitchActive: 'Activo',
+    consentAnalyticsCard: 'Analíticas',
+    consentBadgeOptional: 'Opcional',
+    consentAnalyticsCopy:
+      'Nos ayudan a medir el rendimiento, detectar incidencias y mejorar la experiencia sin identificarte directamente.',
+    consentAnalyticsAria: 'Activar o desactivar cookies analíticas',
+    consentMarketingCard: 'Marketing',
+    consentMarketingCopy:
+      'Personalizan comunicaciones y campañas que podrían interesarte según tus gustos y pedidos previos.',
+    consentMarketingAria: 'Activar o desactivar comunicaciones de marketing',
+    consentManageTitle: 'Gestiona tus preferencias',
+    consentManageStepOne: 'Haz clic en el botón “Preferencias de privacidad” en el pie de página.',
+    consentManageStepTwo: 'Selecciona cada categoría para ver su descripción y activar o desactivar según tus necesidades.',
+    consentManageStepThree:
+      'Guarda los cambios. Tus ajustes se sincronizarán en todos los dispositivos donde utilices la misma cuenta.',
+    consentManageNote:
+      'Siempre podrás retirar tu consentimiento sin afectar la legalidad del procesamiento previo a la revocación.',
+    consentRightsTitle: 'Tus derechos de privacidad',
+    consentRightsIntro: 'Dependiendo de tu jurisdicción, puedes ejercer los siguientes derechos:',
+    consentRightsAccess: 'Acceso, rectificación y actualización de tu información personal.',
+    consentRightsDeletion: 'Eliminación o anonimización de datos cuando ya no sean necesarios.',
+    consentRightsPortability: 'Portabilidad de datos en un formato estructurado.',
+    consentRightsObjection: 'Oposición o restricción al procesamiento basado en intereses legítimos.',
+    consentRightsComplaint: 'Presentar quejas ante la autoridad de control competente.',
+    consentRightsContact:
+      'Para ejercer estos derechos, escríbenos a <a href="mailto:privacidad@marxia.ec">privacidad@marxia.ec</a> o envíanos un mensaje vía WhatsApp.',
+    consentRetentionTitle: 'Conservación y seguridad de los datos',
+    consentRetentionBody:
+      'Conservamos los datos personales únicamente durante el tiempo necesario para cumplir con los fines descritos o según lo requiera la ley aplicable. Implementamos cifrado, controles de acceso y monitoreo continuo conforme a NIST CSF, CISA Cyber Essentials y PCI DSS 4.0 para proteger tu información.',
+    consentUpdatesTitle: 'Actualizaciones',
+    consentUpdatesBody:
+      'Revisamos esta política de consentimiento de manera periódica. Notificaremos cambios sustanciales mediante banners en el sitio y una fecha de actualización visible. Última actualización: <time datetime="2024-06-01">1 de junio de 2024</time>.',
+    consentFooterRights: 'Marxia Café y Bocaditos. Todos los derechos reservados.',
+    consentFooterLinksPrefix: 'Consulta también nuestros',
+    consentFooterTerms: 'Términos y Condiciones',
+    consentFooterAnd: 'y la',
+    consentFooterPreferences: 'configuración de preferencias',
+    consentFooterSuffix: 'para administrar cookies.',
+
+    // Términos legales
+    termsMetaTitle: 'Términos y Condiciones | Marxia Café y Bocaditos',
+    termsMetaDescription:
+      'Condiciones de uso, responsabilidades y políticas de servicio de Marxia Café y Bocaditos.',
+    termsHeading: 'Términos y Condiciones',
+    termsTagline: 'Acuerdo de servicio para utilizar los canales digitales de Marxia Café y Bocaditos.',
+    termsScopeHeading: '1. Alcance y aceptación',
+    termsScopeBody:
+      'Estos Términos y Condiciones regulan el acceso y uso del sitio web, aplicaciones y canales asociados de Marxia Café y Bocaditos. Al acceder o realizar un pedido aceptas cumplir este acuerdo, la Política de Consentimiento y cualquier lineamiento complementario publicado en la plataforma.',
+    termsServicesHeading: '2. Servicios ofrecidos',
+    termsServicesBody:
+      'Ofrecemos experiencias gastronómicas, reservas y entregas a domicilio dentro de las zonas habilitadas de Guayaquil. Las características y disponibilidad pueden variar según temporadas, aforo y eventos especiales. Cualquier cambio será comunicado mediante el sitio o canales oficiales de mensajería.',
+    termsOrdersHeading: '3. Pedidos, pagos y facturación',
+    termsOrdersConfirm:
+      'Los pedidos se considerarán confirmados únicamente tras recibir un comprobante de pago o validación manual.',
+    termsOrdersPayments:
+      'Aceptamos métodos de pago habilitados en el flujo de checkout, incluyendo tarjetas compatibles con PCI DSS y transferencias.',
+    termsOrdersInvoices:
+      'Emitimos facturas o comprobantes electrónicos bajo normativa ecuatoriana cuando corresponda.',
+    termsOrdersPricing:
+      'Los precios incluyen impuestos aplicables; cualquier cargo adicional se informará antes de confirmar la orden.',
+    termsUserHeading: '4. Responsabilidades del usuario',
+    termsUserAccurateInfo: 'Proporcionar información veraz y completa al registrarse o solicitar entregas.',
+    termsUserSchedule: 'Respetar horarios de entrega y políticas de cancelación establecidas.',
+    termsUserConduct: 'No utilizar el sitio para actividades ilícitas, fraudulentas o que comprometan la seguridad.',
+    termsUserAllergens: 'Revisar las alertas de alérgenos y fichas nutricionales antes de realizar un pedido.',
+    termsPrivacyHeading: '5. Privacidad y consentimiento',
+    termsPrivacyBody:
+      'El tratamiento de datos personales se rige por nuestra <a href="consent.html">Gestión de consentimiento</a>. Utilizamos controles técnicos y organizativos alineados con NIST CSF, CISA Cyber Essentials y PCI DSS para salvaguardar la confidencialidad, integridad y disponibilidad de tu información.',
+    termsIntellectualHeading: '6. Propiedad intelectual',
+    termsIntellectualBody:
+      'Todos los contenidos, marcas, logotipos, fotografías y diseños son propiedad de Marxia Café y Bocaditos o de sus licenciantes. No se permite reproducir, modificar o distribuir el material sin autorización escrita previa.',
+    termsLiabilityHeading: '7. Limitación de responsabilidad',
+    termsLiabilityBody:
+      'Hacemos esfuerzos razonables por garantizar un servicio seguro y disponible. Sin embargo, no asumimos responsabilidad por daños indirectos, interrupciones o pérdidas derivadas de causas fuera de nuestro control, incluyendo fallos de terceros, cortes eléctricos o eventos de fuerza mayor.',
+    termsChangesHeading: '8. Modificaciones',
+    termsChangesBody:
+      'Podemos actualizar estos términos para reflejar cambios regulatorios, de producto o de negocio. Las versiones modificadas entrarán en vigencia al publicarse en esta página, indicando la fecha de última actualización. El uso continuado posterior a los cambios implica tu aceptación.',
+    termsContactHeading: '9. Contacto',
+    termsContactBody:
+      'Si tienes consultas legales o sobre estos términos, escríbenos a <a href="mailto:legal@marxia.ec">legal@marxia.ec</a> o contáctanos mediante WhatsApp. También puedes visitar nuestra sede en Guayaquil previa cita.',
+    termsLawHeading: '10. Ley aplicable y jurisdicción',
+    termsLawBody:
+      'Este acuerdo se rige por las leyes de la República del Ecuador. Cualquier controversia se resolverá ante los tribunales competentes de Guayaquil, sin perjuicio de mecanismos alternativos de resolución que las partes acuerden.',
+    termsUpdated: 'Última actualización: <time datetime="2024-06-01">1 de junio de 2024</time>.',
+    termsFooterRights: 'Marxia Café y Bocaditos. Todos los derechos reservados.',
+    termsFooterLinksPrefix: 'Revisa también nuestra',
+    termsFooterConsent: 'Gestión de consentimiento',
+    termsFooterAnd: 'y las políticas de seguridad aplicadas en el',
+    termsFooterSite: 'sitio principal',
+    termsFooterSuffix: '.',
+
+    // Etiquetas de cajones y FAB
     chatTitle: 'Chat en vivo',
     chatWelcome: 'Hola 👋 ¿En qué podemos ayudarte hoy?',
     chatLabel: 'Mensaje',

--- a/terms.html
+++ b/terms.html
@@ -3,34 +3,61 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Términos y Condiciones | Marxia Café y Bocaditos</title>
+    <title data-i18n="termsMetaTitle">Términos y Condiciones | Marxia Café y Bocaditos</title>
     <meta
       name="description"
       content="Condiciones de uso, responsabilidades y políticas de servicio de Marxia Café y Bocaditos."
+      data-i18n="termsMetaDescription"
+      data-i18n-attr="content"
     >
     <link rel="canonical" href="https://marxia.ec/terminos">
     <link rel="stylesheet" href="main.css">
   </head>
   <body>
-    <a class="skip-link" href="#main">Saltar al contenido principal</a>
+    <a class="skip-link" href="#main" data-i18n="skipToContent">Saltar al contenido principal</a>
     <header class="legal__header" role="banner">
       <div class="legal__branding">
-        <h1>Términos y Condiciones</h1>
-        <p>Acuerdo de servicio para utilizar los canales digitales de Marxia Café y Bocaditos.</p>
+        <h1 data-i18n="termsHeading">Términos y Condiciones</h1>
+        <p data-i18n="termsTagline">Acuerdo de servicio para utilizar los canales digitales de Marxia Café y Bocaditos.</p>
       </div>
       <nav aria-label="Legal">
         <ul class="legal__nav-list">
-          <li><a href="index.html">Inicio</a></li>
-          <li><a href="order.html">Ordenar</a></li>
-          <li><a href="consent.html">Gestión de consentimiento</a></li>
+          <li><a href="index.html" data-i18n="navHome">Inicio</a></li>
+          <li><a href="order.html" data-i18n="navOrder">Ordenar</a></li>
+          <li><a href="consent.html" data-i18n="navConsent">Gestión de consentimiento</a></li>
         </ul>
       </nav>
+      <div class="legal__preferences">
+        <nav aria-label="Preferencias rápidas" class="landing__toggles" data-i18n="quickPreferences" data-i18n-attr="aria-label" data-i18n-skip-text="true">
+          <div class="toggle-group" role="group" aria-label="Language selection" data-i18n="languageSelection" data-i18n-attr="aria-label" data-i18n-skip-text="true">
+            <button
+              class="toggle-button toggle-button--language"
+              id="languageToggle"
+              type="button"
+              role="switch"
+              aria-checked="false"
+              aria-label="Switch to English"
+              data-current-language="es"
+            >ES</button>
+          </div>
+
+          <div class="toggle-group" role="group" aria-label="Theme selection" data-i18n="themeSelection" data-i18n-attr="aria-label" data-i18n-skip-text="true">
+            <button
+              class="toggle-button toggle-button--theme"
+              id="themeToggle"
+              type="button"
+              aria-pressed="false"
+            aria-label="Cambiar a tema oscuro"
+            >Oscuro</button>
+          </div>
+        </nav>
+      </div>
     </header>
 
     <main id="main" class="legal__main" tabindex="-1">
       <section class="legal__section" aria-labelledby="scope">
-        <h2 id="scope">1. Alcance y aceptación</h2>
-        <p>
+        <h2 id="scope" data-i18n="termsScopeHeading">1. Alcance y aceptación</h2>
+        <p data-i18n="termsScopeBody">
           Estos Términos y Condiciones regulan el acceso y uso del sitio web, aplicaciones y canales asociados de Marxia Café y
           Bocaditos. Al acceder o realizar un pedido, aceptas cumplir este acuerdo, así como la Política de Consentimiento y
           cualquier lineamiento complementario comunicado en la plataforma.
@@ -38,8 +65,8 @@
       </section>
 
       <section class="legal__section" aria-labelledby="services">
-        <h2 id="services">2. Servicios ofrecidos</h2>
-        <p>
+        <h2 id="services" data-i18n="termsServicesHeading">2. Servicios ofrecidos</h2>
+        <p data-i18n="termsServicesBody">
           Ofrecemos experiencias gastronómicas, reservas y entregas a domicilio dentro de las zonas habilitadas de Guayaquil.
           Las características y disponibilidad pueden variar según temporadas, aforo y eventos especiales. Cualquier cambio será
           comunicado mediante el sitio o canales oficiales de mensajería.
@@ -47,28 +74,28 @@
       </section>
 
       <section class="legal__section" aria-labelledby="orders">
-        <h2 id="orders">3. Pedidos, pagos y facturación</h2>
+        <h2 id="orders" data-i18n="termsOrdersHeading">3. Pedidos, pagos y facturación</h2>
         <ul>
-          <li>Los pedidos se considerarán confirmados únicamente tras recibir un comprobante de pago o validación manual.</li>
-          <li>Aceptamos métodos de pago habilitados en el flujo de checkout, incluyendo tarjetas compatibles con PCI DSS y transferencias.</li>
-          <li>Emitimos facturas o comprobantes electrónicos bajo normativa ecuatoriana cuando corresponda.</li>
-          <li>Los precios incluyen impuestos aplicables; cualquier cargo adicional se informará antes de confirmar la orden.</li>
+          <li data-i18n="termsOrdersConfirm">Los pedidos se considerarán confirmados únicamente tras recibir un comprobante de pago o validación manual.</li>
+          <li data-i18n="termsOrdersPayments">Aceptamos métodos de pago habilitados en el flujo de checkout, incluyendo tarjetas compatibles con PCI DSS y transferencias.</li>
+          <li data-i18n="termsOrdersInvoices">Emitimos facturas o comprobantes electrónicos bajo normativa ecuatoriana cuando corresponda.</li>
+          <li data-i18n="termsOrdersPricing">Los precios incluyen impuestos aplicables; cualquier cargo adicional se informará antes de confirmar la orden.</li>
         </ul>
       </section>
 
       <section class="legal__section" aria-labelledby="user-duties">
-        <h2 id="user-duties">4. Responsabilidades del usuario</h2>
+        <h2 id="user-duties" data-i18n="termsUserHeading">4. Responsabilidades del usuario</h2>
         <ul>
-          <li>Proporcionar información veraz y completa al registrarse o solicitar entregas.</li>
-          <li>Respetar horarios de entrega y políticas de cancelación establecidas.</li>
-          <li>No utilizar el sitio para actividades ilícitas, fraudulentas o que comprometan la seguridad.</li>
-          <li>Revisar las alertas de alérgenos y fichas nutricionales antes de realizar un pedido.</li>
+          <li data-i18n="termsUserAccurateInfo">Proporcionar información veraz y completa al registrarse o solicitar entregas.</li>
+          <li data-i18n="termsUserSchedule">Respetar horarios de entrega y políticas de cancelación establecidas.</li>
+          <li data-i18n="termsUserConduct">No utilizar el sitio para actividades ilícitas, fraudulentas o que comprometan la seguridad.</li>
+          <li data-i18n="termsUserAllergens">Revisar las alertas de alérgenos y fichas nutricionales antes de realizar un pedido.</li>
         </ul>
       </section>
 
       <section class="legal__section" aria-labelledby="consent-reference">
-        <h2 id="consent-reference">5. Privacidad y consentimiento</h2>
-        <p>
+        <h2 id="consent-reference" data-i18n="termsPrivacyHeading">5. Privacidad y consentimiento</h2>
+        <p data-i18n="termsPrivacyBody" data-i18n-html="true">
           El tratamiento de datos personales se rige por nuestra <a href="consent.html">Gestión de consentimiento</a>. Utilizamos
           controles técnicos y organizativos alineados con NIST CSF, CISA Cyber Essentials y PCI DSS para salvaguardar la
           confidencialidad, integridad y disponibilidad de tu información.
@@ -76,16 +103,16 @@
       </section>
 
       <section class="legal__section" aria-labelledby="intellectual-property">
-        <h2 id="intellectual-property">6. Propiedad intelectual</h2>
-        <p>
+        <h2 id="intellectual-property" data-i18n="termsIntellectualHeading">6. Propiedad intelectual</h2>
+        <p data-i18n="termsIntellectualBody">
           Todos los contenidos, marcas, logotipos, fotografías y diseños son propiedad de Marxia Café y Bocaditos o de sus
           licenciantes. No se permite reproducir, modificar o distribuir el material sin autorización escrita previa.
         </p>
       </section>
 
       <section class="legal__section" aria-labelledby="limitations">
-        <h2 id="limitations">7. Limitación de responsabilidad</h2>
-        <p>
+        <h2 id="limitations" data-i18n="termsLiabilityHeading">7. Limitación de responsabilidad</h2>
+        <p data-i18n="termsLiabilityBody">
           Hacemos esfuerzos razonables por garantizar un servicio seguro y disponible. Sin embargo, no asumimos responsabilidad
           por daños indirectos, interrupciones o pérdidas derivadas de causas fuera de nuestro control, incluyendo fallos de
           terceros, cortes eléctricos o eventos de fuerza mayor.
@@ -93,8 +120,8 @@
       </section>
 
       <section class="legal__section" aria-labelledby="changes">
-        <h2 id="changes">8. Modificaciones</h2>
-        <p>
+        <h2 id="changes" data-i18n="termsChangesHeading">8. Modificaciones</h2>
+        <p data-i18n="termsChangesBody">
           Podemos actualizar estos términos para reflejar cambios regulatorios, de producto o de negocio. Las versiones
           modificadas entrarán en vigencia al publicarse en esta página, indicando la fecha de última actualización. El uso
           continuado posterior a los cambios implica tu aceptación.
@@ -102,8 +129,8 @@
       </section>
 
       <section class="legal__section" aria-labelledby="contact">
-        <h2 id="contact">9. Contacto</h2>
-        <p>
+        <h2 id="contact" data-i18n="termsContactHeading">9. Contacto</h2>
+        <p data-i18n="termsContactBody" data-i18n-html="true">
           Si tienes consultas legales o sobre estos términos, escríbenos a
           <a href="mailto:legal@marxia.ec">legal@marxia.ec</a> o contáctanos mediante WhatsApp. También puedes visitar nuestra
           sede en Guayaquil previa cita.
@@ -111,25 +138,29 @@
       </section>
 
       <section class="legal__section" aria-labelledby="governing-law">
-        <h2 id="governing-law">10. Ley aplicable y jurisdicción</h2>
-        <p>
+        <h2 id="governing-law" data-i18n="termsLawHeading">10. Ley aplicable y jurisdicción</h2>
+        <p data-i18n="termsLawBody">
           Este acuerdo se rige por las leyes de la República del Ecuador. Cualquier controversia se resolverá ante los tribunales
           competentes de Guayaquil, sin perjuicio de mecanismos alternativos de resolución que las partes acuerden.
         </p>
-        <p class="legal__updated">Última actualización: <time datetime="2024-06-01">1 de junio de 2024</time>.</p>
+        <p class="legal__updated" data-i18n="termsUpdated" data-i18n-html="true">Última actualización: <time datetime="2024-06-01">1 de junio de 2024</time>.</p>
       </section>
     </main>
 
     <footer class="legal__footer">
-      <p>&copy; <span id="legalYear"></span> Marxia Café y Bocaditos. Todos los derechos reservados.</p>
+      <p>&copy; <span id="legalYear"></span> <span data-i18n="termsFooterRights">Marxia Café y Bocaditos. Todos los derechos reservados.</span></p>
       <p>
-        Revisa también nuestra <a href="consent.html">Gestión de consentimiento</a> y las políticas de seguridad aplicadas en el
-        <a href="index.html#seguridad">sitio principal</a>.
+        <span data-i18n="termsFooterLinksPrefix">Revisa también nuestra</span>
+        <a href="consent.html" data-i18n="termsFooterConsent">Gestión de consentimiento</a>
+        <span data-i18n="termsFooterAnd">y las políticas de seguridad aplicadas en el</span>
+        <a href="index.html#seguridad" data-i18n="termsFooterSite">sitio principal</a>
+        <span data-i18n="termsFooterSuffix">.</span>
       </p>
     </footer>
 
     <script>
       document.getElementById('legalYear').textContent = new Date().getFullYear();
     </script>
+    <script src="main.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- enable localized language and theme toggles plus bilingual copy on the landing and ordering pages
- localize consent and terms experiences with translated content and navigation updates
- extend the translation runtime, dictionaries, and consent center to support HTML content, events, and fallbacks

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dffe471640832b84ebe5bd2848404f