### PR TITLE
Scale hero typography and add bilingual hero copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,10 +88,10 @@
   <main id="mainContent">
     <section class="landing__hero" aria-labelledby="hero-title">
       <div class="landing__hero-content">
-        <p class="landing__eyebrow">Guayaquil · Ecuador</p>
-        <h1 id="hero-title" class="landing__headline">Mañanas emblemáticas</h1>
-        <h3 class="landing__subheadline">Elige lo que energiza su día.</h3>
-        <p class="landing__promise">Sabores frescos todos los días.</p>
+        <h2 class="landing__eyebrow" data-i18n="heroEyebrow">Guayaquil · Ecuador</h2>
+        <h1 id="hero-title" class="landing__headline" data-i18n="heroHeadline">Mañanas emblemáticas</h1>
+        <h2 class="landing__subheadline" data-i18n="heroSubheadline">Elige lo que energiza su día.</h2>
+        <p class="landing__promise" data-i18n="heroPromise">Sabores frescos todos los días.</p>
       </div>
     </section>
 

--- a/main.css
+++ b/main.css
@@ -397,31 +397,30 @@ body::after {
   display: grid;
   gap: 0.75rem;
 }
-
 .landing__eyebrow {
   margin: 0;
-  text-transform: uppercase;
-  font-weight: 600;
-  letter-spacing: 0.18em;
-  color: var(--text-muted);
-  font-size: 1rem;
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--text-primary);
 }
 
 .landing__headline {
   margin: 0;
-  font-size: 1.5rem;
+  font-size: 2.5rem;
   line-height: 1.05;
 }
 
-.landing__subheadline,
+.landing__subheadline {
+  margin: 0;
+  font-size: 2.8rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
 .landing__hint {
   margin: 0;
   font-weight: 500;
   color: var(--text-muted);
-  font-size: 1.2rem;
-}
-
-.landing__hint {
   font-size: clamp(0.95rem, 2.4vw, 1.2rem);
 }
 
@@ -434,9 +433,9 @@ body::after {
 }
 
 .landing__promise {
-  margin: 1rem 0 0;
-  font-size: 1.2rem;
-  color: var(--text-muted);
+  margin: 0;
+  font-size: 2.5rem;
+  color: var(--text-primary);
 }
 
 .topbar__brand {

--- a/main.js
+++ b/main.js
@@ -31,6 +31,10 @@ const currencyDefaults = Object.freeze({
 
 const translations = Object.freeze({
   en: {
+    heroEyebrow: 'Guayaquil · Ecuador',
+    heroHeadline: 'Signature mornings',
+    heroSubheadline: 'Choose what energizes your day.',
+    heroPromise: 'Fresh flavors every day.',
     headline: 'Marxia Café y Bocaditos',
     tagline: 'Breakfasts, pastries, and deliveries in North Guayaquil.',
     promise: 'Fresh flavors every day.',
@@ -104,6 +108,10 @@ const translations = Object.freeze({
     fabPayLabel: 'Payment summary',
   },
   es: {
+    heroEyebrow: 'Guayaquil · Ecuador',
+    heroHeadline: 'Mañanas emblemáticas',
+    heroSubheadline: 'Elige lo que energiza su día.',
+    heroPromise: 'Sabores frescos todos los días.',
     headline: 'Marxia Café y Bocaditos',
     tagline: 'Desayunos, bocaditos y entregas en el Norte de Guayaquil.',
     promise: 'Sabores frescos todos los días.',


### PR DESCRIPTION
## Summary
- enlarge the hero location, headline, subheadline, and promise typography to the requested rem sizes
- connect the hero copy to the translation system so Spanish renders by default and English appears when toggled
- extend the translation dictionaries with the new hero strings for both languages

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e004ab4908832bb593f0085b3dd639