### PR TITLE
Align hero content and reposition order page toggles

### DIFF
--- a/main.css
+++ b/main.css
@@ -589,22 +589,26 @@ body::after {
   gap: clamp(2.5rem, 4vw, 3.5rem);
 }
 
+
 .hero {
   background: var(--surface);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-layered);
   padding: clamp(2rem, 5vw, 3rem);
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
+  align-items: center;
   --shape-font-boost: 0px;
   transition: box-shadow var(--transition), filter var(--transition), transform var(--transition);
 }
 
 .hero__content {
   max-width: 640px;
-  text-align: center;
+  text-align: left;
   display: grid;
   gap: 1.25rem;
+  justify-items: start;
+  align-items: start;
 }
 
 .hero h1 {
@@ -618,7 +622,20 @@ body::after {
 .hero__cta {
   display: grid;
   gap: 0.75rem;
-  justify-items: center;
+  justify-items: start;
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.hero__toggles {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .hero__promise {

--- a/order.html
+++ b/order.html
@@ -43,44 +43,6 @@
 </head>
 <body>
   <a class="skip-link" href="#mainContent" data-i18n="skipToContent">Saltar al contenido</a>
-  <header class="topbar" role="banner">
-    <div class="topbar__brand">
-      <a href="index.html" class="topbar__home" aria-label="Volver a la página principal" data-i18n="navHomeAria" data-i18n-attr="aria-label" data-i18n-skip-text="true">
-        <span aria-hidden="true" class="logo">☕</span>
-        <span class="topbar__home-text" data-i18n="navHome">Inicio</span>
-      </a>
-      <p>
-        <strong id="brandTitle" data-i18n="brandTitle">Marxia Café y Bocaditos</strong>
-        <span id="brandSubtitle" data-i18n="brandSubtitle">Breakfasts, pastries &amp; catering in Guayaquil</span>
-        <span data-i18n="contactWhatsAppLabel">WhatsApp:</span><a href="https://wa.me/593958741463"
-        target="_blank" rel="noopener noreferrer" aria-label="WhatsApp +593 958 741 463">+593 958 741 463</a>
-      </p>
-    </div>
- <nav aria-label="Preferencias rápidas" class="landing__toggles" data-i18n="quickPreferences" data-i18n-attr="aria-label" data-i18n-skip-text="true">
-        <div class="toggle-group" role="group" aria-label="Language selection" data-i18n="languageSelection" data-i18n-attr="aria-label" data-i18n-skip-text="true">
-          <button
-            class="toggle-button toggle-button--language"
-            id="languageToggle"
-            type="button"
-            role="switch"
-            aria-checked="false"
-            aria-label="Switch to English"
-            data-current-language="es"
-          >ES</button>
-        </div>
-
-        <div class="toggle-group" role="group" aria-label="Theme selection" data-i18n="themeSelection" data-i18n-attr="aria-label" data-i18n-skip-text="true">
-          <button
-            class="toggle-button toggle-button--theme"
-            id="themeToggle"
-            type="button"
-            aria-pressed="false"
-            aria-label="Cambiar a tema oscuro"
-          >Oscuro</button>
-        </div>
-      </nav>
-  </header>
-
   <main class="page" id="mainContent">
     <section class="hero" aria-labelledby="hero-title">
       <div class="hero__content">
@@ -88,7 +50,32 @@
         <h2 class="tagline" data-i18n="tagline">Desayunos, bocaditos y entregas en el Norte de Guayaquil.</h2>
         <h2 class="hero__promise" data-i18n="promise">Sabores frescos todos los días.</h2>
         <div class="hero__cta">
-          <button id="orderButton" class="cta" type="button" data-i18n="orderNow">Order now</button>
+          <div class="hero__actions">
+            <button id="orderButton" class="cta" type="button" data-i18n="orderNow">Order now</button>
+            <nav aria-label="Preferencias rápidas" class="landing__toggles hero__toggles" data-i18n="quickPreferences" data-i18n-attr="aria-label" data-i18n-skip-text="true">
+              <div class="toggle-group" role="group" aria-label="Language selection" data-i18n="languageSelection" data-i18n-attr="aria-label" data-i18n-skip-text="true">
+                <button
+                  class="toggle-button toggle-button--language"
+                  id="languageToggle"
+                  type="button"
+                  role="switch"
+                  aria-checked="false"
+                  aria-label="Switch to English"
+                  data-current-language="es"
+                >ES</button>
+              </div>
+
+              <div class="toggle-group" role="group" aria-label="Theme selection" data-i18n="themeSelection" data-i18n-attr="aria-label" data-i18n-skip-text="true">
+                <button
+                  class="toggle-button toggle-button--theme"
+                  id="themeToggle"
+                  type="button"
+                  aria-pressed="false"
+                  aria-label="Cambiar a tema oscuro"
+                >Oscuro</button>
+              </div>
+            </nav>
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- remove the top banner from the order page to simplify the hero layout
- place the language and theme toggle controls alongside the primary "Order now" call-to-action
- adjust hero styling so the headline, subtext, and controls align to the left margin

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e257e518f8832bb65924bbbd46e2a6