### PR TITLE
Adjust menu and carousel styling

### DIFF
--- a/main.css
+++ b/main.css
@@ -982,23 +982,22 @@ body::after {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.75rem;
+  gap: 0.5rem;
   border: none;
-  background: var(--surface-strong);
+  background: none;
   color: inherit;
-  padding: 1rem 1.5rem;
-  border-radius: var(--radius-md);
-  font-size: calc(clamp(1.2rem, 3vw, 1.4rem) + (var(--shape-font-boost) * 0.45));
+  padding: 0.25rem 0;
+  border-radius: 0;
+  font-size: 3.5rem;
   font-weight: 700;
   cursor: pointer;
-  transition: transform var(--transition), box-shadow var(--transition), font-size var(--transition);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18);
+  transition: transform var(--transition), font-size var(--transition);
 }
 
 .accordion__trigger span:first-child {
   flex: 0 1 auto;
   text-align: center;
-  font-size: 1.5rem;
+  font-size: 1em;
 }
 
 .accordion__trigger:focus-visible {
@@ -1014,12 +1013,12 @@ body::after {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  background: var(--chip-bg);
-  color: var(--chip-text);
-  font-size: 1.25rem;
+  width: auto;
+  height: auto;
+  border-radius: 0;
+  background: none;
+  color: inherit;
+  font-size: 1em;
   transition: transform var(--transition);
   margin-left: 0;
 }
@@ -1078,22 +1077,25 @@ body::after {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: var(--surface);
-  color: var(--chip-text);
-  box-shadow: var(--shadow-layered);
+  background: none;
+  color: var(--text-main);
+  box-shadow: none;
   cursor: pointer;
-  transition: transform var(--transition), box-shadow var(--transition), background var(--transition),
-    filter var(--transition);
+  transition: transform var(--transition), color var(--transition);
   z-index: 2;
   touch-action: manipulation;
 }
 
-.product-carousel__control:hover,
+.product-carousel__control:hover {
+  transform: translateY(-50%) translateY(-2px);
+  color: var(--accent-strong);
+}
+
 .product-carousel__control:focus-visible {
   transform: translateY(-50%) translateY(-2px);
-  box-shadow: var(--shadow-layered-strong);
-  filter: brightness(var(--hover-darken));
-  outline: none;
+  color: var(--accent-strong);
+  outline: 2px solid var(--accent-strong);
+  outline-offset: 4px;
 }
 
 .product-carousel__control:active {
@@ -1115,7 +1117,7 @@ body::after {
 }
 
 .product-carousel__control span {
-  font-size: 2.15rem;
+  font-size: 2.5rem;
   line-height: 1;
 }
 
@@ -1221,7 +1223,7 @@ body::after {
 
 .product-card__info h3 {
   margin: 0;
-  font-size: calc(1.1rem + (var(--shape-font-boost) * 0.5));
+  font-size: 2.5rem;
   transition: font-size var(--transition);
 }
 
@@ -1233,7 +1235,7 @@ body::after {
 .product-card__meta {
   margin: 0;
   color: var(--text-muted);
-  font-size: calc(1.1rem + (var(--shape-font-boost) * 0.45));
+  font-size: 2.5rem;
   transition: font-size var(--transition);
 }
 
@@ -1249,7 +1251,7 @@ body::after {
 
 .product-card__price {
   font-weight: 700;
-  font-size: calc(1.25rem + (var(--shape-font-boost) * 0.55));
+  font-size: 2.5rem;
   text-align: center;
   transition: font-size var(--transition);
 }
@@ -2493,16 +2495,16 @@ body::after {
   .product-carousel__control {
     width: 44px;
     height: 44px;
-    background: rgba(31, 27, 44, 0.72);
-    color: #ffffff;
-    box-shadow: 0 12px 28px rgba(31, 27, 44, 0.28);
-    backdrop-filter: blur(8px);
+    background: none;
+    color: var(--text-main);
+    box-shadow: none;
+    backdrop-filter: none;
   }
 
   [data-theme="dark"] .product-carousel__control {
-    background: rgba(255, 255, 255, 0.18);
-    color: #ffffff;
-    box-shadow: 0 14px 32px rgba(4, 6, 12, 0.55);
+    background: none;
+    color: var(--text-main);
+    box-shadow: none;
   }
 
   .product-carousel__control--prev {


### PR DESCRIPTION
## Summary
- enlarge the "Our menu" accordion header to 3.5rem and remove its card-style background treatment
- strip background containers from the product carousel controls while enlarging the navigation chevrons
- increase product title, description, and price typography to 2.5rem for the carousel tiles

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e259609a94832b9d41b847774a7ae4