### PR TITLE
Adjust hero layout and copy for Marxia landing

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,10 +88,12 @@
   <main id="mainContent">
     <section class="landing__hero" aria-labelledby="hero-title">
       <div class="landing__hero-content">
-        <h2 class="landing__eyebrow" data-i18n="heroEyebrow">Guayaquil · Ecuador</h2>
-        <h1 id="hero-title" class="landing__headline" data-i18n="heroHeadline">Mañanas emblemáticas</h1>
-        <h2 class="landing__subheadline" data-i18n="heroSubheadline">Elige lo que energiza su día.</h2>
+        <h1 id="hero-title" class="landing__headline" data-i18n="heroHeadline">Marxia Café y Bocaditos</h1>
+        <p class="landing__subheadline" data-i18n="heroSubheadline">Desayunos, bocaditos y entregas en el Norte de Guayaquil.</p>
         <p class="landing__promise" data-i18n="heroPromise">Sabores frescos todos los días.</p>
+        <div class="landing__cta-group">
+          <a class="cta cta--large" href="order.html" data-i18n="orderNow">Ordenar ahora</a>
+        </div>
       </div>
     </section>
 

--- a/main.css
+++ b/main.css
@@ -388,14 +388,17 @@ body::after {
 .landing__hero {
   padding: clamp(3.5rem, 8vw, 7rem) clamp(1.5rem, 6vw, 5.5rem);
   display: grid;
-  justify-items: start;
-  align-items: center;
+  justify-items: center;
+  align-items: start;
 }
 
 .landing__hero-content {
   max-width: 720px;
+  width: 100%;
   display: grid;
   gap: 0.75rem;
+  justify-items: center;
+  text-align: center;
 }
 .landing__eyebrow {
   margin: 0;
@@ -406,8 +409,8 @@ body::after {
 
 .landing__headline {
   margin: 0;
-  font-size: clamp(2.25rem, 6.4vw, 3.5rem);
-  line-height: 1.05;
+  font-size: 2.2rem;
+  line-height: 1.1;
 }
 
 .landing__subheadline {

--- a/main.js
+++ b/main.js
@@ -58,11 +58,11 @@ const translations = Object.freeze({
     landingFooterSecurity: 'Marxia Café y Bocaditos. Security reinforced with PCI DSS, NIST CSF, and CISA best practices.',
 
     // Landing & ordering
-    heroEyebrow: 'Guayaquil · Ecuador',
-    heroTitle: 'Signature mornings',
-    heroSubtitle: 'Choose what energizes your day.',
-    heroHeadline: 'Signature mornings',
-    heroSubheadline: 'Choose what energizes your day.',
+    heroEyebrow: 'Marxia Café y Bocaditos',
+    heroTitle: 'Marxia Café y Bocaditos',
+    heroSubtitle: 'Breakfasts, bites, and deliveries across North Guayaquil.',
+    heroHeadline: 'Marxia Café y Bocaditos',
+    heroSubheadline: 'Breakfasts, bites, and deliveries across North Guayaquil.',
     heroPromise: 'Fresh flavors every day.',
     headline: 'Marxia Café y Bocaditos',
     tagline: 'Breakfasts, pastries, and deliveries in North Guayaquil.',
@@ -318,11 +318,11 @@ const translations = Object.freeze({
       'Marxia Café y Bocaditos. Seguridad reforzada con buenas prácticas PCI DSS, NIST CSF y CISA.',
 
     // Landing y pedidos
-    heroEyebrow: 'Guayaquil · Ecuador',
-    heroTitle: 'Mañanas emblemáticas',
-    heroSubtitle: 'Elige lo que energiza tu día.',
-    heroHeadline: 'Mañanas emblemáticas',
-    heroSubheadline: 'Elige lo que energiza tu día.',
+    heroEyebrow: 'Marxia Café y Bocaditos',
+    heroTitle: 'Marxia Café y Bocaditos',
+    heroSubtitle: 'Desayunos, bocaditos y entregas en el Norte de Guayaquil.',
+    heroHeadline: 'Marxia Café y Bocaditos',
+    heroSubheadline: 'Desayunos, bocaditos y entregas en el Norte de Guayaquil.',
     heroPromise: 'Sabores frescos todos los días.',
     headline: 'Marxia Café y Bocaditos',
     tagline: 'Desayunos, bocaditos y entregas en el Norte de Guayaquil.',

--- a/src/js/i18n/dictionary.js
+++ b/src/js/i18n/dictionary.js
@@ -27,11 +27,11 @@ export const translations = Object.freeze({
     landingFooterSecurity: 'Marxia Café y Bocaditos. Security reinforced with PCI DSS, NIST CSF, and CISA best practices.',
 
     // Landing & ordering
-    heroEyebrow: 'Guayaquil · Ecuador',
-    heroTitle: 'Signature mornings',
-    heroSubtitle: 'Choose what energizes your day.',
-    heroHeadline: 'Signature mornings',
-    heroSubheadline: 'Choose what energizes your day.',
+    heroEyebrow: 'Marxia Café y Bocaditos',
+    heroTitle: 'Marxia Café y Bocaditos',
+    heroSubtitle: 'Breakfasts, bites, and deliveries across North Guayaquil.',
+    heroHeadline: 'Marxia Café y Bocaditos',
+    heroSubheadline: 'Breakfasts, bites, and deliveries across North Guayaquil.',
     heroPromise: 'Fresh flavors every day.',
     headline: 'Marxia Café y Bocaditos',
     tagline: 'Breakfasts, pastries, and deliveries in North Guayaquil.',
@@ -287,11 +287,11 @@ export const translations = Object.freeze({
       'Marxia Café y Bocaditos. Seguridad reforzada con buenas prácticas PCI DSS, NIST CSF y CISA.',
 
     // Landing y pedidos
-    heroEyebrow: 'Guayaquil · Ecuador',
-    heroTitle: 'Mañanas emblemáticas',
-    heroSubtitle: 'Elige lo que energiza tu día.',
-    heroHeadline: 'Mañanas emblemáticas',
-    heroSubheadline: 'Elige lo que energiza tu día.',
+    heroEyebrow: 'Marxia Café y Bocaditos',
+    heroTitle: 'Marxia Café y Bocaditos',
+    heroSubtitle: 'Desayunos, bocaditos y entregas en el Norte de Guayaquil.',
+    heroHeadline: 'Marxia Café y Bocaditos',
+    heroSubheadline: 'Desayunos, bocaditos y entregas en el Norte de Guayaquil.',
     heroPromise: 'Sabores frescos todos los días.',
     headline: 'Marxia Café y Bocaditos',
     tagline: 'Desayunos, bocaditos y entregas en el Norte de Guayaquil.',


### PR DESCRIPTION
## Summary
- center the hero content, add the primary order CTA, and update the hero copy
- tweak hero typography to use a 2.2rem headline and align the section to the top-center
- refresh both English and Spanish i18n dictionaries with the new hero messaging

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e26396a26c832bb8af1d24f903f818