### PR TITLE
Center hero order CTA and reposition toggles

### DIFF
--- a/main.css
+++ b/main.css
@@ -628,7 +628,7 @@ body::after {
 .hero__cta {
   display: grid;
   gap: 0.75rem;
-  justify-items: start;
+  justify-items: center;
 }
 
 .hero__actions {
@@ -642,6 +642,10 @@ body::after {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+}
+
+.hero__actions .hero__toggles {
+  order: -1;
 }
 
 .hero__actions {


### PR DESCRIPTION
## Summary
- center the hero call-to-action block on the order page for better visual balance
- display the language and theme toggle group to the left of the order button by adjusting flex item order

## Testing
- No automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2d3f08cb0832b8e6a83951d1bb6a5